### PR TITLE
Migrating bv-ui-pixels-displayed to module in the core

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ module's directory.
 - [namespacer](./lib/namespacer)
 - [parseUri](./lib/parseUri)
 - [performance](./lib/performance)
+- [pixelsDisplayed](./lib/pixelsDisplayed)
 
 [1]: ./CONTRIBUTING.md
 [2]: https://nodejs.org/download/

--- a/lib/pixelsDisplayed/README.md
+++ b/lib/pixelsDisplayed/README.md
@@ -1,0 +1,19 @@
+# pixelsDisplayed
+
+> A module for detecting whether an element is located within the viewport
+
+## Usage
+
+```js
+var bvUIPixelsDisplayed = require('bv-ui-core/lib/pixelsDisplayed');
+var pixelsDisplayedVertical = bvUIPixelsDisplayed.pixelsDisplayedVertical;
+var pixelsDisplayedHorizontal = bvUIPixelsDisplayed.pixelsDisplayedHorizontal;
+
+
+if (pixelsDisplayedVertical(element) > 0) {
+  // element is vertically within viewport
+  if (pixelsDisplayedHorizontal(element) > 0) {
+    // element is both vertically and horizontally within viewport
+  }
+}
+```

--- a/lib/pixelsDisplayed/index.js
+++ b/lib/pixelsDisplayed/index.js
@@ -1,0 +1,113 @@
+/**
+ * @fileOverview Checks visibility of an element by calculating the
+ * visible pixels for vertical and horizontal viewport.
+ * This is a migration of repository bv-ui-pixels-displayed
+ */
+var global = require('../global');
+
+function getDimensions () {
+  var window = global;
+  var docEl = window.document && window.document.documentElement;
+  return {
+    height: window.innerHeight || docEl.clientHeight,
+    width: window.innerWidth || docEl.clientWidth
+  };
+}
+
+function pixelsDisplayedVertical (el) {
+  var rect = el.getBoundingClientRect();
+  var displayed;
+  var windowHeight = module.exports.getDimensions().height;
+
+  // There are five potential DOM node positions relative to the viewport:
+  // * Completely above the viewport, not visible
+  // * Completely below the viewport, not visible
+  // * A top portion (or all) of the DOM node is visible
+  // * A middle portion of the DOM node is visible
+  // * A bottom portion of the DOM node is visible
+
+  if (rect.top <= 0) {
+    // The top of the node is at or above the top of the viewport,
+    // so the top plus its height would be how much is shown.
+    // However, we never want to provide a negative number for amount displayed.
+    displayed = Math.max(rect.top + rect.height, 0);
+
+    // Once we know how much is potentially showing, we want to ensure that we don't over-report.
+    // If the window height is less than our calculated display, use that.
+    displayed = Math.min(displayed, windowHeight);
+
+    // Cases handled:
+    // * Completely above the viewport, not visible
+    //   * First displayed value would be 0, as the sum would be negative and so Math.max would return 0
+    //   * Second displayed will remain 0, as that is (hopefully) less than viewport height
+    // * A middle portion of the DOM node is visible, or a bottom portion of the DOM node is visible
+    //   * First displayed value will be the height of the DOM node below the top of the viewport
+    //   * Second displayed value will be either that height, or the height of the viewport itself
+
+    return displayed;
+  }
+
+    // If the top of our rectangle is greater than the viewport's height,
+    // we're not visible, as the node is completely below the viewport.
+  if (rect.top >= windowHeight) { return 0; }
+
+  // At this point, the only remaining case is that the top of the DOM node is
+  // somewhere in the viewport. We can determine the maximum possible amount
+  // displayed rather easily, by determining how much distance there is between
+  // the top of the bounding rectangle and the viewport's height.
+  // However, if this is larger than our DOM node, we don't want to report more
+  // displayed than the node's full height;
+  return Math.min(windowHeight - rect.top, rect.height);
+}
+
+function pixelsDisplayedHorizontal (el) {
+  var rect = el.getBoundingClientRect();
+  var displayed;
+
+  var windowWidth = module.exports.getDimensions().width;
+
+  // There are five potential DOM node positions relative to the viewport:
+  // * Completely to the left of the viewport, not visible
+  // * Completely to the right of the viewport, not visible
+  // * A left portion (or all) of the DOM node is visible
+  // * A middle portion of the DOM node is visible
+  // * A right portion of the DOM node is visible
+
+  if (rect.left <= 0) {
+    // The left of the node is at or to the left of the viewport,
+    // so the left plus its width would be how much is shown.
+    // However, we never want to provide a negative number for amount displayed.
+    displayed = Math.max(rect.left + rect.width, 0);
+
+    // Once we know how much is potentially showing, we want to ensure that we don't over-report.
+    // If the window weight is less than our calculated display, use that.
+    displayed = Math.min(displayed, windowWidth);
+
+    // Cases handled:
+    // * Completely to the left of the viewport, not visible
+    //   * First displayed value would be 0, as the sum would be negative and so Math.max would return 0
+    //   * Second displayed will remain 0, as that is (hopefully) less than viewport width
+    // * A middle portion of the DOM node is visible, or a right portion of the DOM node is visible
+    //   * First displayed value will be the width of the DOM node to the right of the left border of the viewport
+    //   * Second displayed value will be either that width, or the width of the viewport itself
+
+    return displayed;
+  }
+
+  // If the left of our rectangle is greater than the viewport's width,
+  // we're not visible, as the node is completely to the right of the viewport.
+  if (rect.left >= windowWidth) { return 0; }
+
+  // At this point, the only remaining case is that the left of the DOM node is
+  // somewhere in the viewport. We can determine the maximum possible amount
+  // displayed rather easily, by determining how much distance there is between
+  // the left of the bounding rectangle and the viewport's width.
+  // However, if this is larger than our DOM node, we don't want to report more
+  // displayed than the node's full width;
+  return Math.min(windowWidth - rect.left, rect.width);
+}
+
+module.exports = { getDimensions: getDimensions,
+  pixelsDisplayedHorizontal: pixelsDisplayedHorizontal,
+  pixelsDisplayedVertical: pixelsDisplayedVertical
+};

--- a/test/unit/pixelsDisplayed/index.spec.js
+++ b/test/unit/pixelsDisplayed/index.spec.js
@@ -1,0 +1,271 @@
+/**
+ * @fileOverview
+ * Unit tests for the Pixels Displayed module.
+ */
+
+var module = require('../../../lib/pixelsDisplayed');
+
+describe('lib/pixelsDisplayed', function () {
+  var pixelsDisplayedVertical;
+  var pixelsDisplayedHorizontal;
+  var sinonSandbox, stub;
+
+  var rect = {};
+
+  var el = {
+    getBoundingClientRect: function () {
+      return rect;
+    }
+  };
+
+  function stubAccessor () {
+    sinonSandbox = sinon.sandbox.create();
+    stub = sinonSandbox.stub(module, 'getDimensions', function () {
+      return {
+        width: 500,
+        height: 500
+      }
+    });
+  }
+
+  before(function () {
+    pixelsDisplayedVertical = module.pixelsDisplayedVertical;
+    pixelsDisplayedHorizontal = module.pixelsDisplayedHorizontal;
+  });
+
+  beforeEach(function () {
+    stubAccessor();
+    rect = {
+      height: 200,
+      top: 100,
+      width: 200,
+      left: 100
+    };
+  });
+
+  afterEach(function () {
+    // we do expect stubbed method to have been called during each test
+    sinon.assert.called(stub);
+    sinonSandbox.restore();
+  });
+
+  describe('element is hidden vertically', function () {
+    describe('element is smaller than viewport', function () {
+      it('should be hidden when element is way above viewport', function () {
+        rect.top = -9999;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is right above viewport', function () {
+        rect.top = -200;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is way below viewport', function () {
+        rect.top = 9999;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is right below viewport', function () {
+        rect.top = 500;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(0);
+      });
+    });
+
+    describe('element is bigger than viewport', function () {
+      beforeEach(function () {
+        rect.height = 1000;
+      });
+
+      it('should be hidden when element is way above viewport', function () {
+        rect.top = -9999;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is right above viewport', function () {
+        rect.top = -1000;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is way below viewport', function () {
+        rect.top = 9999;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is right below viewport', function () {
+        rect.top = 1000;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(0);
+      });
+    });
+  });
+
+  describe('element is hidden horizontally', function () {
+    describe('element is smaller than viewport', function () {
+      it('should be hidden when element is way to the left of the viewport', function () {
+        rect.left = -9999;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is just to the left of the viewport', function () {
+        rect.left = -200;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is way to the right of the viewport', function () {
+        rect.left = 9999;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is just to the right of the viewport', function () {
+        rect.left = 500;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(0);
+      });
+    });
+
+    describe('element is bigger than viewport', function () {
+      beforeEach(function () {
+        rect.width = 1000;
+      });
+
+      it('should be hidden when element is way to the left of the viewport', function () {
+        rect.left = -9999;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is just to the left of the viewport', function () {
+        rect.left = -1000;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is way to the right of the viewport', function () {
+        rect.left = 9999;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(0);
+      });
+
+      it('should be hidden when element is just to the right of the viewport', function () {
+        rect.left = 1000;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(0);
+      });
+    });
+  });
+
+  describe('element is visible vertically', function () {
+    describe('element is smaller than viewport', function () {
+      it('element should be visible when top position is 0', function () {
+        rect.top = 0;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(200);
+      });
+
+      it('element should be visible when top position is greater than 0', function () {
+        rect.top = 499;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(1);
+      });
+
+      it('element should be visible when top position is less than 0', function () {
+        rect.top = -199;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(1);
+      });
+    });
+
+    describe('element is bigger than viewport', function () {
+      beforeEach(function () {
+        rect.height = 1000;
+      });
+
+      it('element should be visible when top position is 0', function () {
+        rect.top = 0;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(500);
+      });
+
+      it('element should be visible when top position is greater than 0', function () {
+        rect.top = 100;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(400);
+      });
+
+      it('element should be visible when top position is less than 0', function () {
+        rect.top = -600;
+
+        expect(pixelsDisplayedVertical(el)).to.eql(400);
+      });
+    });
+  });
+
+  describe('element is visible horizontally', function () {
+    describe('element is smaller than viewport', function () {
+      it('element should be visible when left position is 0', function () {
+        rect.left = 0;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(200);
+      });
+
+      it('element should be visible when left position is greater than 0', function () {
+        rect.left = 499;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(1);
+      });
+
+      it('element should be visible when left position is less than 0', function () {
+        rect.left = -199;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(1);
+      });
+    });
+
+    describe('element is bigger than viewport', function () {
+      beforeEach(function () {
+        rect.width = 1000;
+      });
+
+      it('element should be visible when left position is 0', function () {
+        rect.left = 0;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(500);
+      });
+
+      it('element should be visible when left position is greater than 0', function () {
+        rect.left = 100;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(400);
+      });
+
+      it('element should be visible when left position is less than 0', function () {
+        rect.left = -600;
+
+        expect(pixelsDisplayedHorizontal(el)).to.eql(400);
+      });
+    });
+  });
+
+  it('Accessor function is working correctly', function () {
+    // Special case, we actually want to call the real function, so restore
+    // sandbox
+    sinonSandbox.restore();
+    var dimensions = module.getDimensions();
+    expect(dimensions.width).to.equal(window.innerWidth);
+    expect(dimensions.height).to.equal(window.innerHeight);
+    // And then re-set-it-up again and call method
+    stubAccessor();
+    dimensions = module.getDimensions();
+  })
+});


### PR DESCRIPTION
This is an attempt to migrate https://github.com/bazaarvoice/bv-ui-pixels-displayed into the core library.
Original library, however, only checked vertical visibility. So I have also duplicated the function and created horizontal version as well. 

Migrated tests, created horizontal tests, added link in Readme.