### PR TITLE
Add logger module to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ module's directory.
 - [global](./lib/global)
 - [ie](./lib/ie)
 - [loader](./lib/loader)
+- [logger](./lib/logger)
 - [namespacer](./lib/namespacer)
 - [parseUri](./lib/parseUri)
 - [performance](./lib/performance)


### PR DESCRIPTION
I came looking for the logger, but couldn't find it in the readme :fries:  