### PR TITLE
Logger group and groupEnd arguments slice fix

### DIFF
--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -95,7 +95,7 @@ var Logger = {
   },
 
   group: function (maxLevel) {
-    var args = arguments.slice(1);
+    var args = Array.prototype.slice.call(arguments, 1);
     if (logLevel <= maxLevel) {
       logger('group', args);
       logger('time',  args);
@@ -103,7 +103,7 @@ var Logger = {
   },
 
   groupEnd: function (maxLevel) {
-    var args = arguments.slice(1);
+    var args = Array.prototype.slice.call(arguments, 1);
     if (logLevel <= maxLevel) {
       logger('groupEnd', args);
       logger('timeEnd',  args);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "karma-sinon": "1.0.4",
     "karma-sinon-chai": "1.1.0",
     "karma-webpack": "1.7.0",
+    "mocha": "2.3.4",
     "node-libs-browser": "0.5.2",
     "phantomjs": "1.9.18",
     "webpack": "1.12.0"

--- a/test/unit/logger/index.spec.js
+++ b/test/unit/logger/index.spec.js
@@ -11,7 +11,9 @@ describe('lib/logger', function () {
     logStub,
     infoStub,
     warnStub,
-    errorStub;
+    errorStub,
+    groupStub,
+    groupEndStub;
 
   before(function () {
     debugStub = sinon.stub(console, 'debug');
@@ -19,6 +21,8 @@ describe('lib/logger', function () {
     infoStub = sinon.stub(console, 'info');
     warnStub = sinon.stub(console, 'warn');
     errorStub = sinon.stub(console, 'error');
+    groupStub = sinon.stub(console, 'group');
+    groupEndStub = sinon.stub(console, 'groupEnd');
   });
 
   afterEach(function () {
@@ -27,6 +31,8 @@ describe('lib/logger', function () {
     infoStub.reset();
     warnStub.reset();
     errorStub.reset();
+    groupStub.reset();
+    groupEndStub.reset();
 
     // reset the log level to the default
     Logger.setLogLevel(Logger.INFO);
@@ -103,4 +109,38 @@ describe('lib/logger', function () {
       }).to.throw(Error, /Assertion failed/);
     });
   })
+
+  describe('#group', function () {
+    it('calls console.group if maxLevel is < the current log level', function () {
+      Logger.group(Logger.INFO);
+      expect(groupStub).to.have.been.called;
+    });
+
+    it('does not call console.group if maxLevel is < the current log level', function () {
+      Logger.group(Logger.DEBUG);
+      expect(groupStub).to.not.have.been.called;
+    });
+
+    it('passes arguments on to console.group', function () {
+      Logger.group(Logger.INFO, 'Test Group');
+      expect(groupStub).to.have.been.calledWith('Test Group');
+    });
+  });
+
+  describe('#groupEnd', function () {
+    it('calls console.groupEnd if maxLevel is < the current log level', function () {
+      Logger.groupEnd(Logger.INFO);
+      expect(groupEndStub).to.have.been.called;
+    });
+
+    it('does not call console.groupEnd if maxLevel is < the current log level', function () {
+      Logger.groupEnd(Logger.DEBUG);
+      expect(groupEndStub).to.not.have.been.called;
+    });
+
+    it('passes arguments on to console.groupEnd', function () {
+      Logger.groupEnd(Logger.INFO, 'Test GroupEnd');
+      expect(groupEndStub).to.have.been.calledWith('Test GroupEnd');
+    });
+  });
 })


### PR DESCRIPTION
Calls to `Logger.group` and `Logger.groupEnd` were throwing errors. I noticed there weren't tests for these, so I added them too.