### PR TITLE
Add css load checker to prevent duplicate loading of style sheet

### DIFF
--- a/lib/cssLoadChecker/README.md
+++ b/lib/cssLoadChecker/README.md
@@ -1,0 +1,19 @@
+# CSS Load Checker
+
+This module provides a means of checking if a CSS file has been loaded already or not. It does this by adding a test div to the page and checking the computed styles of it for the `display: none` style.
+
+```js
+var cssLoadChecker = require('bv-ui-core/lib/cssLoadChecker');
+
+if (cssLoadChecker.isCssLoaded('bv-verify-css-loaded')) {
+  // do stuff if loaded
+}
+else {
+  // do stuff if not loaded (like load it)
+  loader.loadStyleSheet(namespace.cssUrl, callback);
+}
+```
+
+The following methods are provided:
+
+- `isCssLoaded(className)`: Loads a test div onto the page with the given class name and checks for the style `display: none`. If this is set, then the CSS file is assumed to be present so it returns true. Otherwise, it returns false. The test div is removed before this function finishes executing.

--- a/lib/cssLoadChecker/index.js
+++ b/lib/cssLoadChecker/index.js
@@ -1,0 +1,72 @@
+/**
+ * @fileOverview
+ * Provides functions for checking if a stylesheet has been loaded previously
+ */
+
+// Imports
+var global = require('../global');
+var body = require('../body');
+
+/**
+ * Function to add the test div to the page
+ *
+ * @param {string} className - The class name used to check if the css file has loaded yet
+ *  (does not include the '.' out front, just the name)
+ * @return {object} The element that was just created for the purposes of
+ *  testing whether the CSS has loaded or not
+ */
+var _loadTestDiv = function (className) {
+  var testDiv;
+
+  testDiv = global.document.createElement('div');
+  testDiv.style.height = '0px';
+  testDiv.style.width = '0px';
+  testDiv.style.border = '0px';
+  testDiv.className = className;
+  body().appendChild(testDiv);
+
+  return testDiv;
+};
+
+/**
+ * Function to remove the test div from the page
+ *
+ * @param {object} testDiv - The element that was created for the purposes of
+ *  testing whether the CSS has loaded or not
+ */
+var _cleanupTestDiv = function (testDiv) {
+  testDiv.parentNode.removeChild(testDiv);
+};
+
+module.exports = {
+
+  /**
+   * Check the test div to see if the styles have loaded
+   *
+   * @param {string} className - The class name used to check if the css file has loaded yet
+   *  (does not include the '.' out front, just the name)
+   * @return {boolean} True or false as to whether the style sheet has been loaded.
+   */
+  isCssLoaded: function (className) {
+    var testDiv = _loadTestDiv(className);
+    var displayVal;
+    var result = false;
+
+    // add support for IE8
+    if (!global.getComputedStyle) {
+      displayVal = testDiv.currentStyle['display'];
+    }
+    else {
+      var computedStyles = global.getComputedStyle(testDiv);
+      displayVal = computedStyles.getPropertyValue('display');
+    }
+
+    if (displayVal === 'none') {
+      result = true;
+    }
+
+    _cleanupTestDiv(testDiv);
+    return result;
+  }
+
+};

--- a/lib/loader/README.md
+++ b/lib/loader/README.md
@@ -32,6 +32,10 @@ failure in old IE.
 attributes on the created `<script>` element.
 - **timeout**: the time in milliseconds before the loading should be
 considered failed. Defaults to 10000ms.
+- **forceLoad**: a boolean value as to whether the script should
+attempt to be loaded if an earlier attempt was made. Defaults to false.
+- **namespaceName**: a string containing the name of the namespace to check
+if the script has been previously loaded and store the loadedUrls hash
 
 ### loadStyleSheet options
 
@@ -41,6 +45,10 @@ attributes on the created `<link>` element.
 placed. The default insertion point is after the first `<script>` element on the page.
 - **timeout**: the time in milliseconds before the loading should be
 considered failed. Defaults to 10000ms.
+- **forceLoad**: a boolean value as to whether the stylesheet should
+attempt to be loaded if an earlier attempt was made. Defaults to false.
+- **namespaceName**: a string containing the name of the namespace to check
+if the stylesheet has been previously loaded and store the loadedUrls hash
 
 ### loader timeout
 

--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -14,9 +14,11 @@
  */
 
 var global = require('../global');
+var namespacer = require('../namespacer');
 var doc = global.document;
 
 var DEFAULT_TIMEOUT = 10000;
+var loadedUrls = {};
 
 function getFirstScript () {
   return doc.getElementsByTagName('script')[0];
@@ -36,6 +38,14 @@ function validateArguments (url, options, callback) {
     throw new Error('`url` must be a string');
   }
 
+  if (options.namespaceName && typeof options.namespaceName !== 'string') {
+    throw new Error('`options.namespaceName` must be a string');
+  }
+
+  if (options.forceLoad && typeof options.forceLoad !== 'boolean') {
+    throw new Error('`options.forceLoad` must be a boolean');
+  }
+
   if (typeof options.timeout !== 'number') {
     throw new Error('`options.timeout` must be a number');
   }
@@ -46,6 +56,27 @@ function validateArguments (url, options, callback) {
 }
 
 module.exports = {
+  /**
+   * Clears the loaded URLs
+   *
+   * Clears any URLs that might have been stored in the loadedUrls hash, either
+   * locally or in the given namespace(optional). This is needed for testing so
+   * we don't need unique URLs for every test, but rather this can be used as a
+   * means of cleaning up.
+   *
+   * @param {string} [namespace] - contains the name of the namespace to clear
+   *  the loadedUrls hash in.
+   */
+  _clearLoadedUrls: function (namespaceName) {
+    if (namespaceName) {
+      var namespace = namespacer.namespace(namespaceName);
+      namespace.loadedUrls = {};
+    }
+    else {
+      loadedUrls = {};
+    }
+  },
+
   /**
    * Load a script from a URL
    *
@@ -64,9 +95,17 @@ module.exports = {
    *  to be used as attributes on the created `script` element (optional)
    * @param {number} options.timeout - timeout in milliseconds (defaults to
    *  10000ms)
+   * @param {boolean} options.forceLoad - whether to load the script at the
+   *  specified url or not regardless of whether an earlier attempt to do so has
+   *  already been made
+   * @param {string} options.namespaceName - the name of the namespace to check
+   *  if the script has been previously loaded and store the loadedUrls hash
    * @param {function} [callback] - node-style callback
    */
   loadScript: function (url, options, callback) {
+    var _loadedUrls = loadedUrls;
+    var namespace;
+
     if (typeof options === 'function') {
       callback = options;
       options = null;
@@ -76,6 +115,26 @@ module.exports = {
     options.timeout = options.timeout || DEFAULT_TIMEOUT;
 
     validateArguments(url, options, callback);
+
+    /**
+     * The goal of using the namespacer is to allow multiple apps on the same
+     * page to share the properties within the namespace, namely loadedUrls. For
+     * this reason, we are forgoing the use of registerProperty to instantiate
+     * the list of loaded URLs. This will allow the loader module to be run in
+     * different apps but access the same namespace property.
+     */
+
+    if (options.namespaceName) {
+      namespace = namespacer.namespace(options.namespaceName);
+      _loadedUrls = namespace.loadedUrls || {};
+    }
+
+    if (!options.forceLoad && _loadedUrls[url]) {
+      // File at given url has already been loaded and option has not been set
+      // to reload it, so we'll just call the callback and return.
+      callback();
+      return;
+    }
 
     var script = doc.createElement('script');
     var done = false;
@@ -92,6 +151,17 @@ module.exports = {
       clearTimeout(timeoutHandle);
       script.onload = script.onreadystatechange = script.onerror = null;
       script.parentNode.removeChild(script);
+
+      if (!err) {
+        _loadedUrls[url] = true;
+
+        if (options.namespaceName) {
+          namespace.loadedUrls = _loadedUrls;
+        }
+        else {
+          loadedUrls = _loadedUrls;
+        }
+      }
 
       if (typeof callback === 'function') {
         callback(err);
@@ -155,11 +225,19 @@ module.exports = {
    *  to be used as attributes on the created `link` element (optional)
    * @param {number} options.timeout - timeout in milliseconds (defaults to
    *  1000ms)
+   * @param {boolean} options.forceLoad - whether to load the style sheet at the
+   *  specified url or not regardless of whether an earlier attempt to do so has
+   *  already been made
+   * @param {string} options.namespaceName - the name of the namespace to check
+   *  if the stylesheet has been previously loaded and store the loadedUrls hash
    * @param {element} options.injectionNode - node to inject link element
    *  into (defaults to parent node of the first script node)
    * @param {function} [callback] - node-style callback
    */
   loadStyleSheet: function (url, options, callback) {
+    var _loadedUrls = loadedUrls;
+    var namespace;
+
     if (typeof options === 'function') {
       callback = options;
       options = null;
@@ -178,6 +256,26 @@ module.exports = {
       throw new Error('`options.injectionNode` must be a DOM node');
     }
 
+    /**
+     * The goal of using the namespacer is to allow multiple apps on the same
+     * page to share the properties within the namespace, namely loadedUrls. For
+     * this reason, we are forgoing the use of registerProperty to instantiate
+     * the list of loaded URLs. This will allow the loader module to be run in
+     * different apps but access the same namespace property.
+     */
+
+    if (options.namespaceName) {
+      namespace = namespacer.namespace(options.namespaceName);
+      _loadedUrls = namespace.loadedUrls || {};
+    }
+
+    if (!options.forceLoad && _loadedUrls[url]) {
+      // File at given url has already been loaded and option has not been set
+      // to reload it, so we'll just call the callback and return.
+      callback();
+      return;
+    }
+
     var link = doc.createElement('link');
     var done = false;
     var attr;
@@ -192,6 +290,17 @@ module.exports = {
       done = true;
       clearTimeout(timeoutHandle);
       link.onload = link.onreadystatechange = link.onerror = null;
+
+      if (!err) {
+        _loadedUrls[url] = true;
+
+        if (options.namespaceName) {
+          namespace.loadedUrls = _loadedUrls;
+        }
+        else {
+          loadedUrls = _loadedUrls;
+        }
+      }
 
       if (typeof callback === 'function') {
         callback(err);

--- a/test/unit/cssLoadChecker/index.spec.js
+++ b/test/unit/cssLoadChecker/index.spec.js
@@ -1,0 +1,75 @@
+/**
+ * @fileOverview
+ * Unit tests for the cssLoadChecker module.
+ */
+
+// Imports.
+var global = require('../../../lib/global');
+var cssLoadChecker = require('../../../lib/cssLoadChecker');
+
+/**
+ * Helper function to add a test style sheet to the page
+ *
+ * @param {string} className - The class name used to check if the css file has loaded yet.
+ * @return {object} The style element that was added to the page.
+ */
+var addCss = function (className) {
+  var cssStyles = global.document.createElement('style');
+  cssStyles.type = 'text/css';
+  cssStyles.innerHTML = '.' + className + ' { display: none; }';
+  global.document.getElementsByTagName('head')[0].appendChild(cssStyles);
+  return cssStyles;
+};
+
+/**
+ * Helper function to remove a test style sheet from the page
+ *
+ * @param {object} cssStyles - the style element that was added to the page.
+ */
+var removeCss = function (cssStyles) {
+  if (cssStyles) {
+    cssStyles.parentNode.removeChild(cssStyles);
+  }
+};
+
+
+describe('lib/cssLoadChecker', function () {
+
+  var sandbox;
+  var cssStyles;
+  var className = 'bv-verify-css-loaded';
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    removeCss(cssStyles);
+    cssStyles = undefined;
+  });
+
+
+  describe('isCssLoaded', function () {
+
+    it('CSS is not loaded', function () {
+      var test = cssLoadChecker.isCssLoaded(className);
+      expect(test).to.equal(false);
+    });
+
+    it('CSS is loaded', function () {
+      cssStyles = addCss(className);
+      var test = cssLoadChecker.isCssLoaded(className);
+      expect(test).to.equal(true);
+    });
+
+    it('After checking for CSS, test div should be removed', function () {
+      cssLoadChecker.isCssLoaded(className);
+
+      var allTestDivs = global.document.getElementsByClassName(className);
+      expect(allTestDivs.length).to.equal(0);
+    });
+
+  });
+
+});


### PR DESCRIPTION
This adds the cssLoadChecker module, which is a means of preventing the duplicate loading of requested style sheets.

Research was done into the possibility of using the SAS client in bv-ui-core, but this would not work with the existing use case for this module as explained [here](https://github.com/bazaarvoice/bv-ui-core/issues/52#issuecomment-193389675).