### PR TITLE
JST-79: check for callback existence before invoking

### DIFF
--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -132,7 +132,9 @@ module.exports = {
     if (!options.forceLoad && _loadedUrls[url]) {
       // File at given url has already been loaded and option has not been set
       // to reload it, so we'll just call the callback and return.
-      callback();
+      if (typeof callback === 'function') {
+        callback();
+      }
       return;
     }
 
@@ -272,7 +274,9 @@ module.exports = {
     if (!options.forceLoad && _loadedUrls[url]) {
       // File at given url has already been loaded and option has not been set
       // to reload it, so we'll just call the callback and return.
-      callback();
+      if (typeof callback === 'function') {
+        callback();
+      }
       return;
     }
 

--- a/test/unit/loader/index.spec.js
+++ b/test/unit/loader/index.spec.js
@@ -147,6 +147,18 @@ describe('lib/loader', function () {
         }).to.throw(/`callback` must be a function/);
       });
 
+      it('doesn\'t try to execute non-existent callback on second load', function () {
+        expect(function () {
+          window.BV = window.BV || {}
+          window.BV.loadedUrls = {
+            '/base/test/fixtures/lib.loader.loadscript.js': true
+          }
+          loader.loadScript('/base/test/fixtures/lib.loader.loadscript.js', {
+            namespaceName: 'BV',
+            forceLoad: false
+          });
+        }).to.not.throw(Error);
+      });
     });
 
     it('loads the script at `url`', function (done) {
@@ -486,6 +498,19 @@ describe('lib/loader', function () {
         expect(function () {
           loader.loadStyleSheet('/base/test/fixtures/lib.loader.loadstylesheet.css', {}, 123);
         }).to.throw(/`callback` must be a function/);
+      });
+
+      it('doesn\'t try to execute non-existent callback on second load', function () {
+        expect(function () {
+          window.BV = window.BV || {}
+          window.BV.loadedUrls = {
+            '/base/test/fixtures/lib.loader.loadstylesheet.css': true
+          }
+          loader.loadStyleSheet('/base/test/fixtures/lib.loader.loadstylesheet.css', {
+            namespaceName: 'BV',
+            forceLoad: false
+          });
+        }).to.not.throw(Error);
       });
 
       /*


### PR DESCRIPTION
We were unsafely calling `callback` on any subsequent loads after the first of a url.

ezpz check that we just missed.

Also added unit tests that fail in phantom but pass in chrome for some reason. *shrug*