### PR TITLE
Prevent namespaces from being replaced or removed

### DIFF
--- a/lib/namespacer/index.js
+++ b/lib/namespacer/index.js
@@ -64,7 +64,9 @@ module.exports = {
     // If there is no global property yet assigned for this namespace then
     // create one.
     if (global[name] === undefined) {
-      global[name] = new Namespace(name);
+      Object.defineProperty(global, name, {
+        value: new Namespace(name)
+      });
     }
     // If an object already exists for this global property, check to see
     // whether or not it is a Namespace instance or some other form of object.


### PR DESCRIPTION
Currently, namespaces [cannot replace existing namespaces](https://github.com/bazaarvoice/bv-ui-core/blob/master/lib/namespacer/index.js#L88). I'd like to propose that we disallow namespaces being replaced by different values in general.

```javascript
> window.BV
{ a: 1 }
> window.BV.b = 2  // the namespace is extensible
{ a: 1, b: 2 }
> window.BV = { c: 3 }
> window.BV        // but not writable
{ a: 1, b: 2 }     
```

The motivation for this is that my namespace is shared by different runtime consumers, and certain properties on the namespace are guaranteed to be read-only. A consumer could work around this by replacing the entire namespace with writeable properties, which I want to disallow.

P.S. This seems to be a tricky unit test to write. Something in the test runner doesn't seem to be respecting the property descriptor, as writes appear to be allowed anyway, even when the code under test throws an error if modifications to `global[name]` are attempted.