### PR TITLE
SWAT-972: Adding checks to ensure logger code can be imported in webpack.config

### DIFF
--- a/lib/cookie/index.js
+++ b/lib/cookie/index.js
@@ -18,19 +18,21 @@ module.exports = {
    * @param {Boolean} [secure] Whether this is a secure cookie.
    */
   create: function (name, value, days, domain, secure) {
-    var date = new Date();
+    if (global.document) {
+      var date = new Date();
 
-    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-    var expires = days ? ';expires=' + date.toGMTString() : '';
+      date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+      var expires = days ? ';expires=' + date.toGMTString() : '';
 
-    var c = encodeURIComponent(name) + '=' +
-      encodeURIComponent(value) +
-      expires +
-      ';path=/' +
-      (domain ? (';domain=' + domain) : '') +
-      (secure ? (';secure') : '');
+      var c = encodeURIComponent(name) + '=' +
+        encodeURIComponent(value) +
+        expires +
+        ';path=/' +
+        (domain ? (';domain=' + domain) : '') +
+        (secure ? (';secure') : '');
 
-    global.document.cookie = c;
+      global.document.cookie = c;
+    }
   },
 
   /**
@@ -40,19 +42,21 @@ module.exports = {
    * @return {String} The cookie value or null if no such cookie.
    */
   read: function (name) {
-    var nameEQ = encodeURIComponent(name) + '=';
-    var ca = global.document.cookie.split(';');
-    var i;
+    if (global.document && global.document.cookie) {
+      var nameEQ = encodeURIComponent(name) + '=';
+      var ca = global.document.cookie.split(';');
+      var i;
 
-    for (i = 0; i < ca.length; i++) {
-      var c = ca[i];
+      for (i = 0; i < ca.length; i++) {
+        var c = ca[i];
 
-      while (c.charAt(0) === ' ') {
-        c = c.substring(1, c.length);
-      }
+        while (c.charAt(0) === ' ') {
+          c = c.substring(1, c.length);
+        }
 
-      if (c.indexOf(nameEQ) === 0) {
-        return decodeURIComponent(c.substring(nameEQ.length, c.length));
+        if (c.indexOf(nameEQ) === 0) {
+          return decodeURIComponent(c.substring(nameEQ.length, c.length));
+        }
       }
     }
     return null;

--- a/lib/ie/index.js
+++ b/lib/ie/index.js
@@ -10,16 +10,18 @@
 var doc = require('../global').document;
 
 module.exports = (function () {
-  var ie = (function (v, div, undef) {
-    var all = div.getElementsByTagName('i');
+  if (doc) {
+    var ie = (function (v, div, undef) {
+      var all = div.getElementsByTagName('i');
 
-    while (
-      div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->', all[0]
-    ) {
-      // Empty.
-    }
-    return v > 4 ? v : undef;
-  })(3, doc.createElement('div'));
+      while (
+        div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->', all[0]
+      ) {
+        // Empty.
+      }
+      return v > 4 ? v : undef;
+    })(3, doc.createElement('div'));
 
-  return ie;
+    return ie;
+  }
 })();


### PR DESCRIPTION
I need to require logger in webpack.config, to be able to log levels defined with logger. Doing so generates errors. I added couple of checks to ensure that logger can be imported when there is no document to work with.