### PR TITLE
SWAT-1020 -- Adding new 'ready' function/Promise interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Don't store node modules because that's gross
 node_modules
+coverage
 
 # Numerous always-ignore extensions
 *.diff

--- a/lib/application/README.md
+++ b/lib/application/README.md
@@ -31,29 +31,33 @@ namespacer.namespace('APP').registerProperty(
 // loader.load(url).then( ... do something ... );
 ```
 
+## ES6 Considerations
+
+This module takes advantage of Promises, which you may need to [polyfill][3]:
+
+- `Promise`: http://caniuse.com/#feat=promises
+
 ## Methods to be Called by Users
 
 An application instance provides the following methods:
 
-- `ready(callback)`: A method intended for your users to call at any time in
-  order to register a callback which will be invoked as soon as your
-  application has been loaded and its API is available to be used. Callback
-  function should be a standard Node errback signature, where its first
-  expected parameter will be an error (if applicable), and its second
-  parameter will be the application instance.
+- `ready(callback)`: (optional) A method intended for your users to call at
+  any time in order to register a callback which will be invoked as soon as
+  your application has been loaded and its API is available to be used.
+  Callback function should be a standard Node errback signature, where its
+  first expected parameter will be an error (if applicable), and its second
+  parameter will be the application instance. The return value is a Promise
+  that you can chain your callbacks onto. The success callbacks (on your
+  `then` Promise chain) will only be given a single input parameter, the
+  application instance, and your failure callbacks (on your `catch` Promise
+  chain) will only be given a single input parameter,
+  the error.
 
-  Note that the callback itself is optional in environments where ES6 Promises
-  are available for use. In these scenarios, you can use the return value of
-  `ready` as a Promise to chain your callbacks onto. In this case, your
-  success callbacks (on your `then` Promise chain) will only be given a single
-  input parameter, the application instance. Your failure callbacks (on your
-  `catch` Promise chain) will only be given a single input parameter, the
-  error.
-
-  If you opt to mix and match the callback and the Promise interfaces, be
-  aware that all registered callbacks passed to the `ready` function will be
-  executed first, in the order in which they were attached, and then the
-  Promise chain will be resolved or rejected.
+  Note: If you opt to mix and match the callback and the Promise interfaces,
+  be aware that all registered callbacks passed *to* the `ready` function
+  will be executed first, in the order in which they were attached, and then
+  the Promise chain will be resolved or rejected, which will in turn trigger
+  callbacks on the appropriate `then` or `catch` chain.
 
 - `render(config)`: A method intended for your users to call any time after
   this application module is loaded, passing in configuration information
@@ -71,15 +75,11 @@ APP.exampleApp.render({ productId : 1 });
 
 - `processReady(error)`: A method that your core application code can call in
   order to access calls to `ready` that have occurred. The only parameter it
-  accepts is an optional one, for an error to be passed to the callbacks in
-  its queue, and to reject its Promise with, if used in an environment that
-  supports ES6 Promises. It will then replace the original definition of the
-  `ready` method. Queued items are processed synchronously. If your
-  application is being loaded via the BV Loader, the Loader will handle
-  invoking `processReady` automatically, as soon as your application script
-  has been loaded. If there is any error with your script loading, BV Loader
-  will also handle passing the error to your `processReady` function so that
-  it can properly pass it on to its own subscribers.
+  accepts is an optional one, a load error to be passed to the callbacks in
+  its queue, and to reject its Promise with. It will, from that point on,
+  process all callbacks immediately when passed to the `ready` method. Queued
+  items are processed synchronously, so if your callback is a long-running
+  process, you might want to consider wrapping it in a setTimeout.
 - `processQueue(fn)`: A method that your core application code can call in
   order to access calls to `render` that have occurred; the provided function
   will be used to handle those calls, and will then replace the original
@@ -93,3 +93,4 @@ APP.exampleApp.render({ productId : 1 });
 
 [1]: ../loader
 [2]: ../namespacer
+[3]: https://github.com/stefanpenner/es6-promise

--- a/lib/application/README.md
+++ b/lib/application/README.md
@@ -35,6 +35,26 @@ namespacer.namespace('APP').registerProperty(
 
 An application instance provides the following methods:
 
+- `ready(callback)`: A method intended for your users to call at any time in
+  order to register a callback which will be invoked as soon as your
+  application has been loaded and its API is available to be used. Callback
+  function should be a standard Node errback signature, where its first
+  expected parameter will be an error (if applicable), and its second
+  parameter will be the application instance.
+
+  Note that the callback itself is optional in environments where ES6 Promises
+  are available for use. In these scenarios, you can use the return value of
+  `ready` as a Promise to chain your callbacks onto. In this case, your
+  success callbacks (on your `then` Promise chain) will only be given a single
+  input parameter, the application instance. Your failure callbacks (on your
+  `catch` Promise chain) will only be given a single input parameter, the
+  error.
+
+  If you opt to mix and match the callback and the Promise interfaces, be
+  aware that all registered callbacks passed to the `ready` function will be
+  executed first, in the order in which they were attached, and then the
+  Promise chain will be resolved or rejected.
+
 - `render(config)`: A method intended for your users to call any time after
   this application module is loaded, passing in configuration information
   related to a request to render your application.
@@ -49,6 +69,17 @@ APP.exampleApp.render({ productId : 1 });
 
 ## Methods to Be Called by Core Application Code
 
+- `processReady(error)`: A method that your core application code can call in
+  order to access calls to `ready` that have occurred. The only parameter it
+  accepts is an optional one, for an error to be passed to the callbacks in
+  its queue, and to reject its Promise with, if used in an environment that
+  supports ES6 Promises. It will then replace the original definition of the
+  `ready` method. Queued items are processed synchronously. If your
+  application is being loaded via the BV Loader, the Loader will handle
+  invoking `processReady` automatically, as soon as your application script
+  has been loaded. If there is any error with your script loading, BV Loader
+  will also handle passing the error to your `processReady` function so that
+  it can properly pass it on to its own subscribers.
 - `processQueue(fn)`: A method that your core application code can call in
   order to access calls to `render` that have occurred; the provided function
   will be used to handle those calls, and will then replace the original

--- a/lib/application/index.js
+++ b/lib/application/index.js
@@ -4,6 +4,8 @@
  * configuration and rendering.
  */
 
+var global = require('../global');
+
 // --------------------------------------------------------------------------
 // Functions.
 // --------------------------------------------------------------------------
@@ -54,10 +56,35 @@ function processQueue (queue, fn, sync) {
  */
 function Application (config) {
   this.config = config;
+  this._readyQueue = [];
   this._renderQueue = [];
   this._configQueue = [];
+  if (typeof global.Promise === 'function') {
+    this._promise = new Promise(function (resolve, reject) {
+      this._resolve = resolve;
+      this._reject = reject;
+    }.bind(this));
+  }
   return this;
 }
+
+/**
+ * A method that can be called before the "real" application is
+ * loaded; its job is to queue the ready callbacks that are passed,
+ * so that they can be called when the real app arrives.
+ */
+Application.prototype.ready = function (callback) {
+  if (typeof callback === 'function') {
+    this._readyQueue.push(callback);
+  }
+
+  if (typeof global.Promise === 'function') {
+    return this._promise;
+  }
+  else {
+    return this._readyQueue.length;
+  }
+};
 
 /**
  * A method that can be called before the "real" application is
@@ -76,6 +103,52 @@ Application.prototype.render = function (config) {
  */
 Application.prototype.configure = function (config) {
   return this._configQueue.push(config);
+};
+
+/**
+ * The function to be passed to our processQueue function when processing
+ * ready callbacks below.
+ */
+var processReadyFn = function (err, callback) {
+  if (typeof callback === 'function') {
+    callback(err, this);
+  }
+};
+
+/**
+ * To be called by the real application once it is loaded and its API
+ * is fully available to consumers. It processes any passed callbacks as a
+ * queue, then redefines the ready method to process incoming callbacks
+ * immediately. If the current runtime also supports Promises, this will
+ * return a Promise handle that can be used to queue up additional callbacks.
+ *
+ * @param  [Function] callback An optional function to be queued for
+ * processing. Any queued callbacks will be processed prior to resolving the
+ * Promise, if Promises are supported.
+ * @return {Promise | undefined} A Promise handle where Promises are
+ * supported, otherwise undefined.
+ */
+Application.prototype.processReady = function (err) {
+  var processReady = processReadyFn.bind(this, err);
+  processQueue.call(this, this._readyQueue, processReady, true);
+
+  this._readyQueue.push = processReady;
+
+  if (typeof global.Promise === 'function') {
+    this.ready = function (callback) {
+      processReady(callback);
+      return this._promise;
+    };
+    if (err) {
+      this._reject(err);
+    }
+    else {
+      this._resolve(this);
+    }
+  }
+  else {
+    this.ready = processReady;
+  }
 };
 
 /**

--- a/lib/application/index.js
+++ b/lib/application/index.js
@@ -4,8 +4,6 @@
  * configuration and rendering.
  */
 
-var global = require('../global');
-
 // --------------------------------------------------------------------------
 // Functions.
 // --------------------------------------------------------------------------
@@ -59,12 +57,10 @@ function Application (config) {
   this._readyQueue = [];
   this._renderQueue = [];
   this._configQueue = [];
-  if (typeof global.Promise === 'function') {
-    this._promise = new Promise(function (resolve, reject) {
-      this._resolve = resolve;
-      this._reject = reject;
-    }.bind(this));
-  }
+  this._promise = new Promise(function (resolve, reject) {
+    this._resolve = resolve;
+    this._reject = reject;
+  }.bind(this));
   return this;
 }
 
@@ -78,12 +74,7 @@ Application.prototype.ready = function (callback) {
     this._readyQueue.push(callback);
   }
 
-  if (typeof global.Promise === 'function') {
-    return this._promise;
-  }
-  else {
-    return this._readyQueue.length;
-  }
+  return this._promise;
 };
 
 /**
@@ -125,8 +116,7 @@ var processReadyFn = function (err, callback) {
  * @param  [Function] callback An optional function to be queued for
  * processing. Any queued callbacks will be processed prior to resolving the
  * Promise, if Promises are supported.
- * @return {Promise | undefined} A Promise handle where Promises are
- * supported, otherwise undefined.
+ * @return {Promise} A Promise handle to use for additional callbacks.
  */
 Application.prototype.processReady = function (err) {
   var processReady = processReadyFn.bind(this, err);
@@ -134,20 +124,15 @@ Application.prototype.processReady = function (err) {
 
   this._readyQueue.push = processReady;
 
-  if (typeof global.Promise === 'function') {
-    this.ready = function (callback) {
-      processReady(callback);
-      return this._promise;
-    };
-    if (err) {
-      this._reject(err);
-    }
-    else {
-      this._resolve(this);
-    }
+  this.ready = function (callback) {
+    processReady(callback);
+    return this._promise;
+  };
+  if (err) {
+    this._reject(err);
   }
   else {
-    this.ready = processReady;
+    this._resolve(this);
   }
 };
 

--- a/test/unit/application/index.spec.js
+++ b/test/unit/application/index.spec.js
@@ -5,6 +5,7 @@
 
 // Imports.
 var Application = require('../../../lib/application');
+var global = require('../../../lib/global');
 
 describe('lib/application', function () {
 
@@ -20,6 +21,196 @@ describe('lib/application', function () {
 
   afterEach(function () {
     sandbox.restore();
+  });
+
+  describe('ready method', function () {
+
+    it('queues calls to ready', function () {
+      var fn = sandbox.spy();
+
+      expect(application._readyQueue.length).to.equal(0);
+      application.ready(fn);
+      expect(application._readyQueue.length).to.equal(1);
+    });
+
+    it('original ready method always gets replaced', function () {
+      application.originalReady = application.ready;
+      application.processReady();
+
+      expect(application.originalRender).to.not.equal(application.ready);
+    });
+
+    it('automatically processes callbacks after processReady is called', function () {
+      var fn = sandbox.spy();
+
+      application.ready(fn);
+      sinon.assert.notCalled(fn);
+
+      application.processReady();
+      sinon.assert.calledOnce(fn);
+
+      application.ready(fn);
+      sinon.assert.calledTwice(fn);
+    });
+
+    it('returns a Promise when Promises are available', function () {
+      if (typeof global.Promise === 'function') {
+        var returnVal = application.ready();
+        expect(returnVal).to.not.be.a('number');
+        expect(returnVal.then).to.be.a('function');
+      }
+      else {
+        // Auto-pass in this environment
+        expect(true).to.equal(true);
+      }
+    });
+
+    it('automatically processes Promise chain callbacks after processReady is called', function () {
+      if (typeof global.Promise === 'function') {
+        var fn = sandbox.spy();
+
+        application.ready().then(fn);
+        sinon.assert.notCalled(fn);
+
+        application.processReady();
+
+        /**
+         * Apparently, Promises get processed asynchronously, even when
+         * they're not asynchronous processes, e.g., the following code
+         * fails its assertions:
+         *
+         * var fn = sandbox.spy();
+         * var promise = Promise.resolve();
+         * promise.then(fn);
+         * sinon.assert.calledOnce(fn);
+         *
+         * Because of this, we have to wrap our below assertions in a
+         * double layer of setTimeout(0) statements, to defer to the
+         * next event loop before we check the status of our spies.
+         */
+        setTimeout(function () {
+          sinon.assert.calledOnce(fn);
+
+          application.ready().then(fn);
+
+          setTimeout(function () {
+            sinon.assert.calledTwice(fn);
+          }, 0);
+        }, 0);
+      }
+      else {
+        // Auto-pass in this environment
+        expect(true).to.equal(true);
+      }
+    });
+
+    it('returns length of queue when Promises are unavailable', function () {
+      if (typeof global.Promise === 'function') {
+        // Auto-pass in this environment
+        expect(true).to.equal(true);
+      }
+      else {
+        var returnVal;
+        // Invoke .ready() and make sure it returns undefined
+        returnVal = application.ready();
+        expect(returnVal).to.equal(0);
+        returnVal = application.ready(sandbox.spy());
+        expect(returnVal).to.equal(1);
+      }
+    });
+
+  });
+
+  describe('processReady method', function () {
+
+    it('processes the queue sync', function () {
+      var fn = sandbox.spy();
+
+      application.ready(fn);
+      application.processReady();
+
+      sinon.assert.calledOnce(fn);
+
+      application.ready(fn);
+
+      sinon.assert.calledTwice(fn);
+    });
+
+    it('injects its callbacks with its own instance when invoked with no error', function () {
+      if (typeof global.Promise === 'function') {
+        // Auto-pass in this environment
+        expect(true).to.equal(true);
+      }
+      else {
+        var fn = sandbox.spy();
+
+        application.ready(fn);
+        application.processReady();
+
+        sinon.assert.calledWith(fn, [null, application]);
+      }
+    });
+
+    it('injects its callbacks with an error when invoked with an error', function () {
+      if (typeof global.Promise === 'function') {
+        // Auto-pass in this environment
+        expect(true).to.equal(true);
+      }
+      else {
+        var error = new Error('Test Error');
+        var fn = sandbox.spy();
+
+        application.ready(fn);
+        application.processReady(error);
+
+        sinon.assert.calledWith(fn, [error, application]);
+      }
+    });
+
+    it('resolves its promise with its own instance when invoked with no error', function (done) {
+      if (typeof global.Promise === 'function') {
+        application.ready()
+          .then(function (app) {
+            expect(application).to.equal(app);
+          })
+          .catch(function (err) {
+            expect(false).to.equal(true);
+          })
+          .then(function () {
+            done();
+          });
+
+        application.processReady();
+      }
+      else {
+        // Auto-pass in this environment
+        expect(true).to.equal(true);
+      }
+    });
+
+    it('rejects its promise with an error when invoked with an error', function (done) {
+      if (typeof global.Promise === 'function') {
+        var error = new Error('Test Error');
+
+        application.ready()
+          .then(function (app) {
+            expect(false).to.equal(true);
+          })
+          .catch(function (err) {
+            expect(error).to.equal(err);
+          })
+          .then(function () {
+            done();
+          });
+
+        application.processReady(error);
+      }
+      else {
+        // Auto-pass in this environment
+        expect(true).to.equal(true);
+      }
+    });
+
   });
 
   describe('render method', function () {

--- a/test/unit/application/index.spec.js
+++ b/test/unit/application/index.spec.js
@@ -53,7 +53,7 @@ describe('lib/application', function () {
       sinon.assert.calledTwice(fn);
     });
 
-    it('returns a Promise when Promises are available', function () {
+    it('returns a Promise', function () {
       if (typeof global.Promise === 'function') {
         var returnVal = application.ready();
         expect(returnVal).to.not.be.a('number');
@@ -101,21 +101,6 @@ describe('lib/application', function () {
       else {
         // Auto-pass in this environment
         expect(true).to.equal(true);
-      }
-    });
-
-    it('returns length of queue when Promises are unavailable', function () {
-      if (typeof global.Promise === 'function') {
-        // Auto-pass in this environment
-        expect(true).to.equal(true);
-      }
-      else {
-        var returnVal;
-        // Invoke .ready() and make sure it returns undefined
-        returnVal = application.ready();
-        expect(returnVal).to.equal(0);
-        returnVal = application.ready(sandbox.spy());
-        expect(returnVal).to.equal(1);
       }
     });
 


### PR DESCRIPTION
[SWAT-1020](https://bits.bazaarvoice.com/jira/browse/SWAT-1020)

Per a discussion yesterday, it would be nice to be able to queue up callbacks for application classes, which wouldn't fire until the application was deemed 'loaded' and available for interacting with. The intent is that applications loaded via BV Loader should automatically kick off the callback queue once they're finished being loaded.

After some discussing about the interface, we came to an agreement that in environments where ES6 Promises were not available, `ready` will behave as a simple callback aggregator, and return undefined: e.g. `app.ready(callback1); app.ready(callbackN);`. In environments where Promises *are* available, either due to native support, or polyfilled support, it will provide the same callback aggregation, but also return a Promise that can be used to queue up more callbacks (or the Promise interface could be used exclusively), e.g. `app.ready(callback1).then(callback2); app.ready().then(callbackN);`

Callbacks will be given an instance of the loaded application, and when passed to the `ready` function itself, should follow a standard Node errback function signature (err, app), versus when passed via a Promise chain, should split those parameters for their `then` and `catch` branches, e.g. `app.ready((err, app) => {})` or `app.ready().then((app) => {}).catch((err) => {})`.