### PR TITLE
UIA-8376: Fix reference error when reporting failed static assets

### DIFF
--- a/lib/staticAssetLoader/index.js
+++ b/lib/staticAssetLoader/index.js
@@ -231,7 +231,7 @@ module.exports = {
           function (error) {
             if (error) {
               throw new Error(
-                'Failed to load ' + assetsToBeRequested.join(', ') + ': ' + error.toString());
+                'Failed to load ' + assetNamesToBeRequested.join(', ') + ': ' + error.toString());
             }
           }
         );


### PR DESCRIPTION
lol at throwing an error when trying to throw an error because we used the wrong name. 