### PR TITLE
SWAT-1609 -- Adding getOriginalConstructor function

### DIFF
--- a/lib/getOriginalConstructor/README.md
+++ b/lib/getOriginalConstructor/README.md
@@ -1,0 +1,13 @@
+# getOriginalConstructor
+
+This file exposes a utility function to get a reset version of a primitive
+constructor, in the event that a client has overridden or polyfilled prototype
+methods in their own primitives, or used a utility like Prototype.js, which
+does that on its own.
+
+## Usage
+```javascript
+var getOriginalConstructor = require('getOriginalConstructor');
+
+getOriginalConstructor(Array).prototype.forEach(someNodeList, callback);
+```

--- a/lib/getOriginalConstructor/README.md
+++ b/lib/getOriginalConstructor/README.md
@@ -1,7 +1,7 @@
 # getOriginalConstructor
 
 This file exposes a utility function to get a reset version of a primitive
-constructor, in the event that a client has overridden or polyfilled prototype
+constructor, in the event that a site has overridden or polyfilled prototype
 methods in their own primitives, or used a utility like Prototype.js, which
 does that on its own.
 

--- a/lib/getOriginalConstructor/index.js
+++ b/lib/getOriginalConstructor/index.js
@@ -1,0 +1,21 @@
+/**
+ *  @fileOverview
+ *  This file exposes a utility function to get a reset version of a primitive
+ *  constructor, in the event that a client has overridden or polyfilled
+ *  prototype methods in their own primitives, or used a utility like
+ *  Prototype.js, which does that on its own.
+ */
+
+var constructors = {};
+
+var getOriginalConstructor = function getOriginalConstructor (constructor) {
+  if (!constructors[constructor.name]) {
+    var iframe = document.createElement('iframe');
+    iframe.src = 'about:blank';
+    document.head.appendChild(iframe);
+    constructors[constructor.name] = iframe.contentWindow[constructor.name];
+    document.head.removeChild(iframe);
+  } return constructors[constructor.name];
+};
+
+module.exports = getOriginalConstructor;

--- a/lib/getOriginalConstructor/index.js
+++ b/lib/getOriginalConstructor/index.js
@@ -1,7 +1,7 @@
 /**
  *  @fileOverview
  *  This file exposes a utility function to get a reset version of a primitive
- *  constructor, in the event that a client has overridden or polyfilled
+ *  constructor, in the event that a site has overridden or polyfilled
  *  prototype methods in their own primitives, or used a utility like
  *  Prototype.js, which does that on its own.
  */

--- a/test/unit/getOriginalConstructor/index.spec.js
+++ b/test/unit/getOriginalConstructor/index.spec.js
@@ -19,7 +19,7 @@ describe('lib/getOriginalConstructor', function () {
   it('Should return an unaltered constructor', function () {
     // Verify that the original push function matches '[native code]'
     expect(!!originalPush.toString().match(/\[native code]/)).to.equal(true);
-    // Verify that the overridden push function matches '[native code]'
+    // Verify that the overridden push function doesn't match '[native code]'
     expect(!!Array.prototype.push.toString().match(/\[native code]/)).to.equal(false);
 
     // Verify that the getOriginalConstructor function returns a reset

--- a/test/unit/getOriginalConstructor/index.spec.js
+++ b/test/unit/getOriginalConstructor/index.spec.js
@@ -1,0 +1,34 @@
+/**
+ * @fileOverview
+ * Unit tests for the getOriginalConstructor module.
+ */
+
+// Imports.
+var getOriginalConstructor = require('../../../lib/getOriginalConstructor');
+
+describe('lib/getOriginalConstructor', function () {
+  var originalPush = Array.prototype.push;
+  var push = function push () {
+    originalPush.apply(this, arguments);
+  }
+
+  Array.prototype.push = push;
+
+  var originalArray = getOriginalConstructor(Array);
+
+  it('Should return an unaltered constructor', function () {
+    // Verify that the original push function matches '[native code]'
+    expect(!!originalPush.toString().match(/\[native code]/)).to.equal(true);
+    // Verify that the overridden push function matches '[native code]'
+    expect(!!Array.prototype.push.toString().match(/\[native code]/)).to.equal(false);
+
+    // Verify that the getOriginalConstructor function returns a reset
+    // constructor and that its prototype push function matches '[native code]'
+    expect(!!originalArray.prototype.push.toString().match(/\[native code]/)).to.equal(true);
+  });
+
+  it('Should cache the returned constructor for future lookups', function () {
+    expect(getOriginalConstructor(Array)).to.equal(originalArray);
+  });
+
+});


### PR DESCRIPTION
[SWAT-1609](https://bits.bazaarvoice.com/jira/browse/SWAT-1609)

## Problem/Goal
In some situations, clients are overriding prototype functions of primitives (or using Prototype.js, which does that), and some prototype functions we're relying on can throw unexpected errors.

## Solution
Added a method to fetch an original version of the constructor from a throwaway iframe.

## Verification
1. Check out this PR and run the tests.
