### PR TITLE
SWAT-1242 -- Adding fetch polyfill module

### DIFF
--- a/lib/polyfills/README.md
+++ b/lib/polyfills/README.md
@@ -1,8 +1,8 @@
 # Polyfills!
 
 The polyfills contained in this folder can be imported as necessary. They should
-export either the built-in being polyfilled, if found on the global, or the
-polyfill.
+export either the builtin native function(s), if found on the global, or the
+polyfill itself.
 
 ## Usage
 
@@ -14,14 +14,26 @@ const Promise = require('bv-ui-core/lib/polyfills/promise')
 const myPromise = new Promise((resolve, reject) => {/*...*/})
 ```
 
+```js
+const { fetch, Headers } = require('bv-ui-core/lib/polyfills/fetch')
+// Do things with the fetch polyfill!
+fetch(url, {
+  headers: new Headers({
+    'Accept': 'application/json',
+  }),
+}).then(myCallback)
+```
+
 **In webpack**
 
 ```js
 plugins: [
+  // Any references to these items in the bundle will be wrapped in
+  // references to their respective polyfill module exports.
   new webpack.ProvidePlugin({
-    // Any Promise references in the bundle will be wrapped in references to
-    // the polyfill.
-    Promise: 'bv-ui-core/lib/polyfill/promise'
+    Promise: 'bv-ui-core/lib/polyfill/promise',
+    fetch: ['bv-ui-core/lib/polyfill/fetch', 'fetch'],
+    Headers: ['bv-ui-core/lib/polyfill/fetch', 'Headers'],
   })
 ]
 ```

--- a/lib/polyfills/fetch.js
+++ b/lib/polyfills/fetch.js
@@ -1,0 +1,55 @@
+/**
+ * Check for the existence of a builtin fetch function, and return it if it
+ * exists. Otherwise, load whatwg-fetch in a non-globally-polluting way. It
+ * checks for the existence of a 'self' variable to attach itself to, and
+ * otherwise, will attach itself to the global object. Because of that, create
+ * a global.self reference for it to attach to, caching any preexisting value,
+ * and restoring the preexisting value after load, exporting the polyfill (and
+ * its supporting data types) from this module.
+ *
+ * In the case of an existing builtin fetch, return it and its supporting data
+ * types from this module, so that any module that needs fetch or its supporting
+ * data types can import all of them from here, whether they're preexisting or
+ * not.
+ */
+var global = require('../global')
+
+// If fetch is unsupported, or is currently polyfilled, supply our own, just in case
+if (typeof global.fetch === 'undefined' || !global.fetch.toString().match(/\[native code]/)) {
+  // Cache any preexisting value
+  var self = global.self;
+
+  // Create a new version of 'self', complete with things
+  // whatwg-fetch does some internal support checks for.
+  global.self = {
+    URLSearchParams: global.URLSearchParams,
+    Symbol: global.Symbol,
+    FileReader: global.FileReader,
+    Blob: global.Blob,
+    FormData: global.FormData,
+    ArrayBuffer: global.ArrayBuffer,
+  };
+
+  // Require whatwg-fetch, which will search for 'self' and attach to it.
+  require('whatwg-fetch');
+
+  // Export the polyfilled items that were housed in the global.self namespace.
+  module.exports = {
+    fetch: global.self.fetch,
+    Headers: global.self.Headers,
+    Request: global.self.Request,
+    Response: global.self.Response,
+  };
+
+  // Restore the original value of 'self' to the version we cached at the top.
+  global.self = self;
+}
+else {
+  // fetch is natively supported, export it and its support constructors.
+  module.exports = {
+    fetch: global.fetch,
+    Headers: global.Headers,
+    Request: global.Request,
+    Response: global.Response,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
       "pre-commit": "npm run lint",
       "pre-push": "npm run lint && npm test"
     }
+  },
+  "dependencies": {
+    "whatwg-fetch": "^2.0.3"
   }
 }

--- a/test/unit/polyfills/fetch.spec.js
+++ b/test/unit/polyfills/fetch.spec.js
@@ -1,0 +1,59 @@
+/**
+ * @fileOverview
+ * Unit tests for the fetch polyfill module.
+ */
+
+var global = require('../../../lib/global');
+
+describe('lib/polyfills/fetch', function () {
+  var nativeSupport = function () {
+    console.log('[native code]');
+  };
+
+  it('does not polyfill when natively supported', function () {
+    var fetch = global.fetch;
+
+    global.fetch = nativeSupport;
+
+    var fetchModule = require('../../../lib/polyfills/fetch');
+
+    expect(fetchModule.fetch).to.equal(nativeSupport);
+
+    // If we have native fetch support, we can also check these
+    if (fetch) {
+      expect(fetchModule.fetch).to.be.a('function');
+      expect(fetchModule.Headers).to.be.a('function');
+      expect(fetchModule.Request).to.be.a('function');
+      expect(fetchModule.Response).to.be.a('function');
+    }
+
+    global.fetch = fetch;
+
+    // Clear the require cache for the next time it's required
+    delete require.cache[require.resolve('../../../lib/polyfills/fetch')];
+  });
+
+  it('polyfills when not natively supported', function () {
+    var fetch = global.fetch;
+
+    global.fetch = undefined;
+
+    var fetchModule = require('../../../lib/polyfills/fetch');
+
+    expect(fetchModule.fetch).not.to.equal(nativeSupport);
+
+    // Verify that we didn't pollute the global namespace
+    expect(global.fetch).to.equal(undefined);
+
+    // Now that we've polyfilled, we can check these
+    expect(fetchModule.fetch).to.be.a('function');
+    expect(fetchModule.Headers).to.be.a('function');
+    expect(fetchModule.Request).to.be.a('function');
+    expect(fetchModule.Response).to.be.a('function');
+
+    global.fetch = fetch;
+
+    // Clear the require cache for the next time it's required
+    delete require.cache[require.resolve('../../../lib/polyfills/fetch')];
+  });
+})

--- a/test/unit/polyfills/promise.spec.js
+++ b/test/unit/polyfills/promise.spec.js
@@ -1,0 +1,48 @@
+/**
+ * @fileOverview
+ * Unit tests for the Promise polyfill module.
+ */
+
+var global = require('../../../lib/global');
+
+describe('lib/polyfills/promise', function () {
+  var nativeSupport = function () {
+    console.log('[native code]');
+  };
+
+  it('does not polyfill when natively supported', function () {
+    var Promise = global.Promise;
+
+    global.Promise = nativeSupport;
+
+    var PromiseModule = require('../../../lib/polyfills/promise');
+
+    expect(PromiseModule).to.equal(nativeSupport);
+
+    global.Promise = Promise;
+
+    // Clear the require cache for the next time it's required
+    delete require.cache[require.resolve('../../../lib/polyfills/promise')];
+  });
+
+  it('polyfills when not natively supported', function () {
+    var Promise = global.Promise;
+
+    global.Promise = undefined;
+
+    var PromiseModule = require('../../../lib/polyfills/promise');
+
+    expect(PromiseModule).not.to.equal(nativeSupport);
+
+    // Verify that we didn't pollute the global namespace
+    expect(global.Promise).to.equal(undefined);
+
+    // Now that we've polyfilled, we can check this
+    expect(PromiseModule).to.be.a('function');
+
+    global.Promise = Promise;
+
+    // Clear the require cache for the next time it's required
+    delete require.cache[require.resolve('../../../lib/polyfills/promise')];
+  });
+})


### PR DESCRIPTION
[SWAT-1242](https://bits.bazaarvoice.com/jira/browse/SWAT-1242)

## Problem/Goal
We want to be able to use the `fetch` API in our products, but IE11 doesn't support it, and we don't want to unnecessarily polyfill if we natively support it. We also want to make sure that if an existing polyfill is in place, that we use our own official polyfill (in case the existing polyfill doesn't do it to spec). All of this should be done without interfering with the global namespace, so as not to disrupt any client code that may be dependent on their own fetch polyfill.

## Solution
Wrap whatwg-fetch in a module that exposes either the native fetch function (and supporting constructor classes for Headers/Request/Response), or the whatwg-fetch versions of fetch and its supporting constructors.

## Verification
1. Check out this PR.
2. Run the tests, which simulate both an environment with native support and an environment without native support.
3. If further verification is necessary, create a test script to load in your browser, which includes this polyfill file, and load in both Chrome and IE11. Chrome should export the native fetch function, and IE11 should export the polyfilled version.