### PR TITLE
SWAT-1609 -- Bug fixes for IE11

### DIFF
--- a/lib/getOriginalConstructor/index.js
+++ b/lib/getOriginalConstructor/index.js
@@ -8,6 +8,7 @@
 
 var constructors = {};
 var constructorNameRegExp = /function\s+([^\(\s]+)/
+var iframe;
 
 var getOriginalConstructor = function getOriginalConstructor (constructor) {
   var constructorName = constructor.name;
@@ -18,13 +19,17 @@ var getOriginalConstructor = function getOriginalConstructor (constructor) {
     constructorName = constructorNameRegExp.exec(constructor.toString())[1];
   }
 
-  if (!constructors[constructorName]) {
-    var iframe = document.createElement('iframe');
+  if (!iframe) {
+    iframe = document.createElement('iframe');
     iframe.src = 'about:blank';
     document.head.appendChild(iframe);
+  }
+
+  if (!constructors[constructorName]) {
     constructors[constructorName] = iframe.contentWindow[constructorName];
-    document.head.removeChild(iframe);
-  } return constructors[constructorName];
+  }
+
+  return constructors[constructorName];
 };
 
 module.exports = getOriginalConstructor;

--- a/lib/getOriginalConstructor/index.js
+++ b/lib/getOriginalConstructor/index.js
@@ -7,15 +7,24 @@
  */
 
 var constructors = {};
+var constructorNameRegExp = /function\s+([^\(\s]+)/
 
 var getOriginalConstructor = function getOriginalConstructor (constructor) {
-  if (!constructors[constructor.name]) {
+  var constructorName = constructor.name;
+  // IE11 doesn't have a constructor.name property, so just in case any other
+  // browsers also don't, use a simple regex to pull the constructor's name
+  // out of the .toString()'d function declaration, e.g. "function Array()"
+  if (!constructorName) {
+    constructorName = constructorNameRegExp.exec(constructor.toString())[1];
+  }
+
+  if (!constructors[constructorName]) {
     var iframe = document.createElement('iframe');
     iframe.src = 'about:blank';
     document.head.appendChild(iframe);
-    constructors[constructor.name] = iframe.contentWindow[constructor.name];
+    constructors[constructorName] = iframe.contentWindow[constructorName];
     document.head.removeChild(iframe);
-  } return constructors[constructor.name];
+  } return constructors[constructorName];
 };
 
 module.exports = getOriginalConstructor;

--- a/test/unit/getOriginalConstructor/index.spec.js
+++ b/test/unit/getOriginalConstructor/index.spec.js
@@ -31,4 +31,21 @@ describe('lib/getOriginalConstructor', function () {
     expect(getOriginalConstructor(Array)).to.equal(originalArray);
   });
 
+  it('Should return the definition for constructor.name when constructor.name exists', function () {
+    var constructor = function Array () {};
+
+    Object.defineProperty(constructor, 'name', {
+      value: 'Array'
+    })
+
+    // We should pull the Array constructor, with prototype, if this is working properly
+    expect(getOriginalConstructor(constructor)).to.have.property('prototype');
+  });
+
+  it('Should return the definition for the function name where constructor.name doesn\'t exist', function () {
+    var constructor = function Array () {};
+
+    // We should pull the Array constructor, with prototype, if this is working properly
+    expect(getOriginalConstructor(constructor)).to.have.property('prototype');
+  });
 });


### PR DESCRIPTION
IE11 was throwing an error because the constructors hash was being keyed by constructor.name, which doesn't exist in IE11. I added a regex so that we could prefer constructor.name where it was supported, and fallback to regex'ing a name out of the function declaration as a backup for browsers where that wasn't supported. That fixes that issue.

Secondly, there was an issue with returning cached versions of these lookups. The original implementation would create an iframe, stick it in the head, return the constructor from it, and then remove it from the head. In future calls, the cached function would be returned, which would cause IE11 to throw an error about trying to execute code from freed scripts. The options to fix this were to create/attach/detach the iframe on every request to this function, or create the iframe on the first request, and leave it in the head permanently, which is the option I chose, as it's the more lightweight option, and shouldn't interfere with anything else on the page (we're already creating plenty of nodes for our own content anyway).