### PR TITLE
SWAT-DEV: Fix for whatwg-fetch property existence.

### DIFF
--- a/lib/polyfills/fetch.js
+++ b/lib/polyfills/fetch.js
@@ -21,14 +21,16 @@ if (typeof global.fetch === 'undefined' || !global.fetch.toString().match(/\[nat
 
   // Create a new version of 'self', complete with things
   // whatwg-fetch does some internal support checks for.
-  global.self = {
-    URLSearchParams: global.URLSearchParams,
-    Symbol: global.Symbol,
-    FileReader: global.FileReader,
-    Blob: global.Blob,
-    FormData: global.FormData,
-    ArrayBuffer: global.ArrayBuffer,
-  };
+  global.self = {};
+
+  // whatwg-fetch uses 'in' checks which breaks on undefined properties, so we
+  // should check for existence and only add the ones that we know we have.
+  var names = ['URLSearchParams', 'FileReader', 'Blob', 'FormData', 'ArrayBuffer'];
+  names.forEach(function (name) {
+    if (global[name]) {
+      global.self[name] = global[name];
+    }
+  });
 
   // Require whatwg-fetch, which will search for 'self' and attach to it.
   require('whatwg-fetch');


### PR DESCRIPTION
When certain properties were undefined we were still creating a property, which passes the `in` check that whatwg-fetch does.

We actually only need to add to the self object the global properties that exist.

I'm unsure how to write unit tests for this, but in practice it worked on IE11.