### PR TITLE
SWAT-2071 -- Fixing a bug in getOriginalConstructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ module's directory.
 - [date.now](./lib/date.now)
 - [domainPolice](./lib/domainPolice)
 - [evented](./lib/evented)
+- [getOriginalConstructor](./lib/getOriginalConstructor)
 - [global](./lib/global)
 - [ie](./lib/ie)
 - [loader](./lib/loader)
@@ -54,6 +55,7 @@ module's directory.
 - [polyfills](./lib/polyfills)
 - [pixelsDisplayed](./lib/pixelsDisplayed)
 - [staticAssetLoader](./lib/staticAssetLoader)
+- [waitForBody](./lib/waitForBody)
 
 [1]: ./CONTRIBUTING.md
 [2]: https://nodejs.org/download/

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -23,6 +23,9 @@ module.exports = function (config) {
 
     // list of files / patterns to load in the browser.
     files: [
+      // We need the polyfill for testing es6 modules.
+      'node_modules/babel-polyfill/dist/polyfill.js',
+
       // Loaded into the browser test page.
       'test/unit/mochaInit.js',
       'test/unit/**/*.spec.js',
@@ -36,9 +39,6 @@ module.exports = function (config) {
         watched: true,
         nocache: true
       },
-
-      // We need the polyfill for testing es6 modules.
-      'node_modules/babel-polyfill/dist/polyfill.js',
     ],
 
     // List of files to exclude.

--- a/lib/getOriginalConstructor/README.md
+++ b/lib/getOriginalConstructor/README.md
@@ -3,11 +3,13 @@
 This file exposes a utility function to get a reset version of a primitive
 constructor, in the event that a site has overridden or polyfilled prototype
 methods in their own primitives, or used a utility like Prototype.js, which
-does that on its own.
+does that on its own. It returns a Promise that will be resolved with the original primitive constructor.
 
 ## Usage
 ```javascript
-var getOriginalConstructor = require('getOriginalConstructor');
+var getOriginalConstructor = require('bv-ui-core/lib/getOriginalConstructor');
 
-getOriginalConstructor(Array).prototype.forEach(someNodeList, callback);
+getOriginalConstructor(Array).then(function (originalArray) {
+  originalArray.prototype.forEach(someNodeList, callback);
+});
 ```

--- a/lib/getOriginalConstructor/README.md
+++ b/lib/getOriginalConstructor/README.md
@@ -3,7 +3,8 @@
 This file exposes a utility function to get a reset version of a primitive
 constructor, in the event that a site has overridden or polyfilled prototype
 methods in their own primitives, or used a utility like Prototype.js, which
-does that on its own. It returns a Promise that will be resolved with the original primitive constructor.
+does that on its own. It returns a Promise that will be resolved with the
+original primitive constructor.
 
 ## Usage
 ```javascript

--- a/lib/getOriginalConstructor/index.js
+++ b/lib/getOriginalConstructor/index.js
@@ -7,7 +7,8 @@
  */
 
 var constructors = {};
-var constructorNameRegExp = /function\s+([^\(\s]+)/
+// eslint-disable-next-line no-useless-escape
+var constructorNameRegExp = /function\s+([^\(\s]+)/;
 var iframe;
 
 var getOriginalConstructor = function getOriginalConstructor (constructor) {
@@ -22,7 +23,7 @@ var getOriginalConstructor = function getOriginalConstructor (constructor) {
   if (!iframe) {
     iframe = document.createElement('iframe');
     iframe.src = 'about:blank';
-    document.head.appendChild(iframe);
+    document.body.appendChild(iframe);
   }
 
   if (!constructors[constructorName]) {

--- a/lib/getOriginalConstructor/index.js
+++ b/lib/getOriginalConstructor/index.js
@@ -6,31 +6,37 @@
  *  Prototype.js, which does that on its own.
  */
 
+var waitForBody = require('../waitForBody');
+
 var constructors = {};
 // eslint-disable-next-line no-useless-escape
 var constructorNameRegExp = /function\s+([^\(\s]+)/;
 var iframe;
 
 var getOriginalConstructor = function getOriginalConstructor (constructor) {
-  var constructorName = constructor.name;
-  // IE11 doesn't have a constructor.name property, so just in case any other
-  // browsers also don't, use a simple regex to pull the constructor's name
-  // out of the .toString()'d function declaration, e.g. "function Array()"
-  if (!constructorName) {
-    constructorName = constructorNameRegExp.exec(constructor.toString())[1];
-  }
+  return new Promise(function (resolve) {
+    waitForBody(function () {
+      var constructorName = constructor.name;
+      // IE11 doesn't have a constructor.name property, so just in case any other
+      // browsers also don't, use a simple regex to pull the constructor's name
+      // out of the .toString()'d function declaration, e.g. "function Array()"
+      if (!constructorName) {
+        constructorName = constructorNameRegExp.exec(constructor.toString())[1];
+      }
 
-  if (!iframe) {
-    iframe = document.createElement('iframe');
-    iframe.src = 'about:blank';
-    document.body.appendChild(iframe);
-  }
+      if (!iframe) {
+        iframe = document.createElement('iframe');
+        iframe.src = 'about:blank';
+        document.body.appendChild(iframe);
+      }
 
-  if (!constructors[constructorName]) {
-    constructors[constructorName] = iframe.contentWindow[constructorName];
-  }
+      if (!constructors[constructorName]) {
+        constructors[constructorName] = iframe.contentWindow[constructorName];
+      }
 
-  return constructors[constructorName];
+      resolve(constructors[constructorName]);
+    });
+  });
 };
 
 module.exports = getOriginalConstructor;

--- a/lib/waitForBody/README.md
+++ b/lib/waitForBody/README.md
@@ -1,0 +1,21 @@
+# waitForBody
+
+This file exposes a utility function that will invoke its callback once the
+`document.body` tag has been created by the runtime environment. It is
+intended to be used in the case of scripts that execute synchronously in the
+head of a document, prior to document.body being available, yet having a
+dependency on document.body for some reason (e.g. appending DOM nodes). This
+function uses a MutationObserver in order to function, so requires that level
+of support in order to function.
+
+## Usage
+```javascript
+var waitForBody = require('bv-ui-core/lib/waitForBody');
+
+var div = document.createElement('div');
+div.id = 'modalContainer';
+
+waitForBody(function () {
+  document.body.appendChild(div);
+});
+```

--- a/lib/waitForBody/index.js
+++ b/lib/waitForBody/index.js
@@ -1,0 +1,36 @@
+/**
+ * This file exposes a single function that can be used to monitor for
+ * document.body to come into existence. It does not mean that its DOM
+ * is loaded, it only means that the document.body node has been created.
+ */
+
+function checkForBody (callback, documentMutationObserver) {
+  if (document.body) {
+    // Stop observing the root documentElement
+    documentMutationObserver.disconnect()
+
+    // Invoke the callback
+    callback()
+  }
+}
+
+module.exports = function waitForBody (callback) {
+  // If document.body is ready, bail early
+  if (document.body) {
+    callback()
+    return
+  }
+
+  // In case the document.body element doesn't exist yet, set up a mutation
+  // observer on document.documentElement, and each time it's triggered,
+  // check for document.body... When it exists, stop observing this.
+  const documentMutationObserver = new MutationObserver(function () {
+    checkForBody(callback, documentMutationObserver)
+  })
+
+  // Attach to document.documentElement for monitoring
+  documentMutationObserver.observe(document.documentElement, { childList: true, subtree: true })
+
+  // Invoke once, in case document.body already exists
+  checkForBody(callback, documentMutationObserver)
+}

--- a/test/unit/getOriginalConstructor/index.spec.js
+++ b/test/unit/getOriginalConstructor/index.spec.js
@@ -14,38 +14,47 @@ describe('lib/getOriginalConstructor', function () {
 
   Array.prototype.push = push;
 
-  var originalArray = getOriginalConstructor(Array);
+  getOriginalConstructor(Array).then(function (originalArray) {
+    it('Should return an unaltered constructor', function () {
+      // Verify that the original push function matches '[native code]'
+      expect(!!originalPush.toString().match(/\[native code]/)).to.equal(true);
+      // Verify that the overridden push function doesn't match '[native code]'
+      expect(!!Array.prototype.push.toString().match(/\[native code]/)).to.equal(false);
 
-  it('Should return an unaltered constructor', function () {
-    // Verify that the original push function matches '[native code]'
-    expect(!!originalPush.toString().match(/\[native code]/)).to.equal(true);
-    // Verify that the overridden push function doesn't match '[native code]'
-    expect(!!Array.prototype.push.toString().match(/\[native code]/)).to.equal(false);
+      // Verify that the getOriginalConstructor function returns a reset
+      // constructor and that its prototype push function matches '[native code]'
+      expect(!!originalArray.prototype.push.toString().match(/\[native code]/)).to.equal(true);
+    });
 
-    // Verify that the getOriginalConstructor function returns a reset
-    // constructor and that its prototype push function matches '[native code]'
-    expect(!!originalArray.prototype.push.toString().match(/\[native code]/)).to.equal(true);
-  });
+    it('Should cache the returned constructor for future lookups', function (done) {
+      getOriginalConstructor(Array).then(function (newArray) {
+        expect(newArray).to.equal(originalArray);
+        done();
+      });
+    });
 
-  it('Should cache the returned constructor for future lookups', function () {
-    expect(getOriginalConstructor(Array)).to.equal(originalArray);
-  });
+    it('Should return the definition for constructor.name when constructor.name exists', function (done) {
+      var constructor = function Array () {};
 
-  it('Should return the definition for constructor.name when constructor.name exists', function () {
-    var constructor = function Array () {};
+      Object.defineProperty(constructor, 'name', {
+        value: 'Array'
+      });
 
-    Object.defineProperty(constructor, 'name', {
-      value: 'Array'
-    })
+      // We should pull the Array constructor, with prototype, if this is working properly
+      getOriginalConstructor(constructor).then(function (newArray) {
+        expect(newArray).to.have.property('prototype');
+        done();
+      });
+    });
 
-    // We should pull the Array constructor, with prototype, if this is working properly
-    expect(getOriginalConstructor(constructor)).to.have.property('prototype');
-  });
+    it('Should return the definition for the function name where constructor.name doesn\'t exist', function (done) {
+      var constructor = function Array () {};
 
-  it('Should return the definition for the function name where constructor.name doesn\'t exist', function () {
-    var constructor = function Array () {};
-
-    // We should pull the Array constructor, with prototype, if this is working properly
-    expect(getOriginalConstructor(constructor)).to.have.property('prototype');
+      // We should pull the Array constructor, with prototype, if this is working properly
+      getOriginalConstructor(constructor).then(function (newArray) {
+        expect(newArray).to.have.property('prototype');
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
We were previously appending the iframe to document.head, but it seems that in some environments, that causes the iframe's `contentWindow` property to be null, and errors when trying to pull the primitive reference from it. We're now appending it to document.body instead, since it's an empty iframe anyway, with `src="about:blank"`, which appears to clear up that issue.