### PR TITLE
SWAT-4956: Revert Object.assign usage for IE11 compatibility

### DIFF
--- a/lib/domainPolice/index.js
+++ b/lib/domainPolice/index.js
@@ -68,7 +68,16 @@ function domainPolice (domains, hostname) {
   if (domainObject) {
     domain.isValid = true;
 
-    domainState = Object.assign({}, domainState, domainObject);
+    // Manually copying keys, because I can't safely use Object.assign
+    // or the npm object-assign module, or even lodash.assign/lodash.extend,
+    // as they're assuming ES5 environments.
+    //
+    // TODO: Once we drop IE11, simplify.
+    for (var key in domainObject) {
+      if (domainObject.hasOwnProperty(key)) {
+        domainState[key] = domainObject[key];
+      }
+    }
 
     // Special case: If the domain is a valid IPv4 address,
     // remove the leading period.


### PR DESCRIPTION
As you can see from [this diff](https://github.com/bazaarvoice/bv-ui-core/compare/v1.2.1...tnunamak:fix-ie#diff-2018b927d3eb400bb9d2df501087c0d3L76), the only thing I have changed here relative to v1.2.1 is a comment.