### PR TITLE
Make iframe ADA compliant by hiding iframe and adding title

### DIFF
--- a/lib/getOriginalConstructor/index.js
+++ b/lib/getOriginalConstructor/index.js
@@ -28,6 +28,11 @@ var getOriginalConstructor = function getOriginalConstructor (constructor) {
         iframe = document.createElement('iframe');
         iframe.src = 'about:blank';
         iframe.style.display = 'none';
+        iframe.height = '0';
+        iframe.width = '0';
+        iframe.tabIndex = '-1';
+        iframe.title = 'empty';
+        iframe.className = 'hidden';
         document.body.appendChild(iframe);
       }
 


### PR DESCRIPTION
### **Problem**
The iframe being injected onto the DOM is not ADA compliant. 

### **Solution**
Since the iframe contains content that is hidden to users, we can hide the iframe to make it ADA compliant. I used these two articles as references:
https://developer.paciellogroup.com/blog/2010/04/making-sure-hidden-frames-are-hidden/
http://davidmacd.com/blog/is-title-attribute-on-iframe-required-by-wcag.html

### **Verification**
@tnunamak I'm not sure how to verify that the iframe now contains the content that I've added. I believe I need to run this in bv-loader since bv-ui-core is imported there, but I don't know how to run bv-loader and how to import the local version of bv-ui-core on my computer. 