### PR TITLE
CCS-34126: apply CSP-compatible fix

### DIFF
--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -6,6 +6,7 @@
 'use strict'; /* eslint strict:0 */
 
 var getGlobal = function () {
+  if (typeof globalThis !== 'undefined') { return globalThis; }
   if (typeof self !== 'undefined') { return self; }
   if (typeof window !== 'undefined') { return window; }
   if (typeof global !== 'undefined') { return global; }

--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -1,11 +1,15 @@
 /**
  *  @fileOverview Provides a reference to the global object
- *
- *  Functions created via the Function constructor in strict mode are sloppy
- *  unless the function body contains a strict mode pragma. This is a reliable
- *  way to obtain a reference to the global object in any ES3+ environment.
- *  see http://stackoverflow.com/a/3277192/46867
+ *  the below solution works in ES3+ environment and doesn't violates CSP in Chrome apps 
+ *  see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
  */
 'use strict'; /* eslint strict:0 */
 
-module.exports = (new Function('return this;'))(); /* eslint no-new-func:0 */
+var getGlobal = function () {
+  if (typeof self !== 'undefined') { return self; }
+  if (typeof window !== 'undefined') { return window; }
+  if (typeof global !== 'undefined') { return global; }
+  throw new Error('unable to locate global object');
+};
+
+module.exports = getGlobal();


### PR DESCRIPTION
Problem
The Global object is being exposed with CSP violations. 
Without `unsafe-eval` directive value of CSP the code can't be executed and thus Firebird app fails to run on the client end.
This is a part of changes for basic support of CSP scoped in CCS-34125.

Solution
We can provide a reference to the global object by using es6-shim alternative to globalThis global object:
 *  the below solution works in ES3+ environment and doesn't violates CSP in Chrome apps 
 *  see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis

We expect this module to be published with new release version which we can update on Firebird project and deploy. Local testing was performed with the package reference like this  "bv-ui-core": "https://github.com/bodrovphone/bv-ui-core"
Test were successful (CSP didn't flag this piece of code as an error any more).

Verification
@danheberden
I'm not sure if I verified it correctly.
Basically what I did was `npm run test` which gave me Karma tests results with no new errors except for those which were already there before my changes. Of course, test coverage affected by this changes.

see screenshots:
![Karma_debug_runner](https://user-images.githubusercontent.com/18177886/62766888-229eae80-ba9c-11e9-9fb6-50d4efbe5eeb.png)
![coverage](https://user-images.githubusercontent.com/18177886/62766898-27636280-ba9c-11e9-87f3-00114e65c9b7.png)

