### PR TITLE
CCS-34126: apply CSP-compatible fix

### DIFF
--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -1,11 +1,16 @@
 /**
  *  @fileOverview Provides a reference to the global object
- *
- *  Functions created via the Function constructor in strict mode are sloppy
- *  unless the function body contains a strict mode pragma. This is a reliable
- *  way to obtain a reference to the global object in any ES3+ environment.
- *  see http://stackoverflow.com/a/3277192/46867
+ *  the below solution works in ES3+ environment and doesn't violates CSP in Chrome apps 
+ *  see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
  */
 'use strict'; /* eslint strict:0 */
 
-module.exports = (new Function('return this;'))(); /* eslint no-new-func:0 */
+var getGlobal = function () {
+  if (typeof globalThis !== 'undefined') { return globalThis; }
+  if (typeof self !== 'undefined') { return self; }
+  if (typeof window !== 'undefined') { return window; }
+  if (typeof global !== 'undefined') { return global; }
+  throw new Error('unable to locate global object');
+};
+
+module.exports = getGlobal();


### PR DESCRIPTION
This is a copy of [PR#93](https://github.com/bazaarvoice/bv-ui-core/pull/93).

The only problem with that pull request was that it was applied on the latest version of this package. Once we performed [the migration](https://github.com/bazaarvoice/firebird/pull/6244/files) in Firebird repo from 0.14.6 to 2.1.1 we picked up breaking changes .
 
It was discovered in CCS-34612 that bv-ui-core 2.1.1 contains [this update](https://github.com/bazaarvoice/bv-ui-core/commit/8ac7f0a0a470276cdc3800a80553cf7a1a971ca4) which creates window.BV in a read-only manner.

On a Preview Page and also for clients which have both Firebird and SWAT, Firebird blocks SWAT app. 

A solution to this is to create 0.14.7 package of bv-ui-core with the only changes including in this pull request. 

I guess it should be merged with 0.14.7 branch as it is unoccupied version on [npm](https://www.npmjs.com/package/bv-ui-core)

![bv-ui-core_version_history](https://user-images.githubusercontent.com/18177886/65416792-4a09ca80-de01-11e9-80ee-a5ae33376ed2.png)


Summary:
The Global object is being exposed with CSP violations.
Without unsafe-eval directive value of CSP the code can't be executed and thus Firebird app fails to run on the client end.
This is a part of changes for basic support of CSP scoped in CCS-34125.