### PR TITLE
apply CSP fix to v0.5.0 version

### DIFF
--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -1,11 +1,16 @@
 /**
  *  @fileOverview Provides a reference to the global object
- *
- *  Functions created via the Function constructor in strict mode are sloppy
- *  unless the function body contains a strict mode pragma. This is a reliable
- *  way to obtain a reference to the global object in any ES3+ environment.
- *  see http://stackoverflow.com/a/3277192/46867
+ *  the below solution works in ES3+ environment and doesn't violates CSP in Chrome apps 
+ *  see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
  */
 'use strict'; /* eslint strict:0 */
 
-module.exports = (new Function('return this;'))(); /* eslint no-new-func:0 */
+var getGlobal = function () {
+  if (typeof globalThis !== 'undefined') { return globalThis; }
+  if (typeof self !== 'undefined') { return self; }
+  if (typeof window !== 'undefined') { return window; }
+  if (typeof global !== 'undefined') { return global; }
+  throw new Error('unable to locate global object');
+};
+
+module.exports = getGlobal();


### PR DESCRIPTION
**Problem**

We migrated scoutfile dependency 2.0.0 -> 4.0.1  on Firebird repo to apply CSP-compatible fix.

old scoutfile(v2.0.0) has bv-ui-core v0.5.0 as its dependency
new  scoutfile(v4.0.1) includes bv-ui-core v2.1.1

The problem here with [this changes](https://github.com/bazaarvoice/bv-ui-core/commit/8ac7f0a0a470276cdc3800a80553cf7a1a971ca4) on bv-ui-core 0.11.1 which breaks Site Preview and mixed integration (Firebird + SWAT).

**Solution**

A solution would be to apply this changes on bv-ui-core v0.5.0 and release bv-ui-core v0.5.1 containing these changes.

Based on this new package we can update scoutfile and that should be enough :)