### PR TITLE
Prefer window over self as the global object

### DIFF
--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -7,8 +7,8 @@
 
 var getGlobal = function () {
   if (typeof globalThis !== 'undefined') { return globalThis; }
-  if (typeof self !== 'undefined') { return self; }
   if (typeof window !== 'undefined') { return window; }
+  if (typeof self !== 'undefined') { return self; }
   if (typeof global !== 'undefined') { return global; }
   throw new Error('unable to locate global object');
 };


### PR DESCRIPTION
Safari 12.0 does not support `globalThis`, so before this change, `self` was selected as the global in that environment. I observed a case where the global context was then defined to be a `<script>` object but where the window would be preferable.

Any objections?

Btw, [this article](https://mathiasbynens.be/notes/globalthis) describes some of the differences of the different values used here.