### PR TITLE
SWAT-5709: Add error handling to evented.trigger

### DIFF
--- a/lib/evented/index.js
+++ b/lib/evented/index.js
@@ -19,7 +19,37 @@ var ArrayProto = Array.prototype;
 var nativeIndexOf = ArrayProto.indexOf;
 var slice = ArrayProto.slice;
 
-function bind(event, fn) {
+/**
+ * Initialize a custom error handler or default to the BV Loader error reporting
+ * regardless of application. This will automatically be called at the first
+ * invocation of the ".on" method, and can be 
+ * event
+ * @param {Function} fn - the custom callback to be invoked whenever an error is
+ *  detected as the result of a trigger event
+ */
+function setErrorHandler(fn) {
+  this.errorHandler = function(e) {
+    global.console.error(e);
+
+    if (fn) {
+      fn.apply(this, slice.call(arguments))
+    } else {
+      if (global && global.BV && global.BV._private) {
+        global.BV._private.errorReporter()
+          .then(function(reportError) {
+            reportError(
+              new Error(e),
+              {
+                extra: arguments
+              }
+            )
+          });
+      }
+    }
+  }
+}
+
+function bind(event, fn, errorHandler) {
   var i, part;
   var events = this.events = this.events || {};
   var parts = event.split(/\s+/);
@@ -29,6 +59,11 @@ function bind(event, fn) {
     events[(part = parts[i])] = events[part] || [];
     events[part].push(fn);
   }
+
+  if (this.errorHandler === undefined) {
+    this.setErrorHandler(errorHandler ? errorHandler : undefined);
+  }
+
   return this;
 }
 
@@ -78,7 +113,12 @@ function trigger(event) {
     try {
       events[event][i].apply(this, args);
     }
-    catch (e) {}
+    catch (e) {
+      this.errorHandler(e, {
+        event: event,
+        details: arguments
+      });
+    }
   }
   return this;
 }
@@ -106,6 +146,7 @@ module.exports = function () {
   this.off = unbind;
   this.trigger = this.emit = trigger;
   this.one = this.once = one;
+  this.setErrorHandler = setErrorHandler;
 
   return this;
 };

--- a/test/unit/evented/index.spec.js
+++ b/test/unit/evented/index.spec.js
@@ -26,4 +26,23 @@ describe('lib/import', function () {
     expect(m.once).to.be.a('function');
   });
 
+  it('creates an errorHandler function correctly', function () {
+    function M () {}
+
+    evented.call(M.prototype);
+    var m = new M();
+
+    expect(m.errorHandler).to.eql(undefined);
+    m.on('test_event', function () {
+      throw new Error('test error');
+    });
+    expect(m.errorHandler).to.be.a('function');
+
+    var spy = sinon.spy();
+    m.setErrorHandler(spy);
+
+    m.trigger('test_event');
+    expect(spy).to.have.been.called;
+  })
+
 });


### PR DESCRIPTION
[SWAT-5709](https://bits.bazaarvoice.com/jira/browse/SWAT-5709]

## The Problem
As Robby has documented in the above Jira ticket and also [this Github issue](https://github.com/bazaarvoice/bv-ui-core/issues/96), the `evented` wrapper is currently swallowing errors whenever a `.trigger` event fails. This obviously makes debugging a lot harder, and could potentially also be swallowing significant bugs that we just don't know about.

## The Solution
I've added a `.setErrorHandler` method to the `evented` constructor. This method takes a callback to be executed whenever a `.trigger` method ends up throwing an error.

`.setErrorHandler` is called the very first time a call to `.on` is made, no matter what, and can also be called at any time to change the behavior of the handler. No matter happens, the error is logged to the console for debugging purposes, and if the callback is provided, then the method executes that callback. If there is no callback provided, the function falls back to a default handler which utilizes the `BV._private.errorReporter`, if available, to log that error to Sentry, passing along both the error object and any additional arguments that were given to the function.

### Verification
1. `git fetch bv && git checkout bv/pr/xxx`
2. `npm run test` and make sure the tests pass
3. Use `npm link` to connect your local `bv-ui-core` to `bv-loader`
4. Run `util/deploy-client.js -c bv-loader-qa --local -s main_site && npm run serve:built` in `bv-loader` to build a local bv.js for bv-loader-qa
5. Visit the [test page](https://apps-qa.bazaarvoice.com/test/index.html?client=bv-loader-qa&site=main_site&environment=production&locale=en_US&async=true&debug=true&mobile=false&internalEnvironments=false&local=true&localPort=&useOrigin=true&bv_segment=&internalParams=true&feature-html=JTNDZGl2JTIwZGF0YS1idi1wcm9kdWN0LWlkJTNEJTIycHJvZHVjdDElMjIlMjBkYXRhLWJ2LXNob3clM0QlMjJyYXRpbmdfc3VtbWFyeSUyMiUzRSUwQSUzQyUyRmRpdiUzRSUwQSUzQ2RpdiUyMGRhdGEtYnYtcHJvZHVjdC1pZCUzRCUyMnByb2R1Y3QxJTIyJTIwZGF0YS1idi1zaG93JTNEJTIycmV2aWV3cyUyMiUzRSUwQSUzQyUyRmRpdiUzRQ==&legacyDisplayCode=&legacyHostname=&metaUsertoken=), being sure to set the `local` flag to true if it isn't already.
6. In your console, first register an `.on` event on `BV.reviews`, like so:
```javascript
BV.reviews.on('test_event', () => {
  throw new Error('test error')
});
```
7. Trigger your test event:
```javascript
BV.reviews.trigger('test_event');
```
8. You should see an error thrown in the console, and if you check the network tab you should see a request to the `errors` endpoint since we didn't provide a callback and the constructor defaulted to the BV Loader error reporter.

<a href="https://gyazo.com/4aeba6df9a647d7db21e4e799a9873c0"><img src="https://i.gyazo.com/4aeba6df9a647d7db21e4e799a9873c0.png" alt="Image from Gyazo" width="875"/></a>

9. Repeat steps 6 and 7, except in between the two, register a custom error handler callback:
```javascript
BV.reviews.setErrorHandler((e) => console.log('HERE IS THE ERROR', e));
```
10. You shouldn't see any network request go out, but you should see both the error and the console log from the custom callback.
11. Repeat steps 9 and 10, except instead of invoking `.setErrorHandler` directly, simply provide the callback as the third argument in your `.on` call.