### PR TITLE
SWAT-5931:added incentivizedStats query param to statistics request url

### DIFF
--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -73,15 +73,18 @@ function getStatistics({
     throw new TypeError("type must be 'Reviews' or 'NativeReviews'");
   }
 
-  const uri =
+  let uri =
     `https://${envPrefix}.bazaarvoice.com/data/statistics.json` +
     `?apiversion=${API_VERSION}` +
     `&passkey=${key}` +
     `&stats=${type}` +
-    `&incentivizedStats=${showIncentivizedReviews}` +
     Object.keys(filters)
       .map(filter => `&filter=${filter}:${filters[filter]}`)
       .join();
+
+  if (showIncentivizedReviews) {
+    uri = uri + `&incentivizedStats=${showIncentivizedReviews}`;
+  }
 
   // Clone the productIds so we can manipulate it.
   productIds = [...productIds];

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -6,7 +6,7 @@
 const envPrefixMap = {
   qa: 'qa.api',
   staging: 'stg.api',
-  production: 'api',
+  production: 'api'
 };
 
 // Default configuration
@@ -54,7 +54,7 @@ function getStatistics({
   key,
   type,
   showIncentivizedReviews = false,
-  filters = {},
+  filters = {}
 }) {
   if (!productIds || !Array.isArray(productIds)) {
     throw new TypeError('productIds must be an array');

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -53,7 +53,7 @@ function getStatistics({
   environment,
   key,
   type,
-  showIncentivizedReviews = false,
+  incentivized = false,
   filters = {}
 }) {
   if (!productIds || !Array.isArray(productIds)) {
@@ -82,8 +82,11 @@ function getStatistics({
       .map(filter => `&filter=${filter}:${filters[filter]}`)
       .join();
 
-  if (showIncentivizedReviews) {
-    uri = uri + `&incentivizedStats=${showIncentivizedReviews}`;
+  // We should add `incentivizedStats` request param in case
+  // if `incentivized` flag is enabled that means such reviews
+  // have to be loaded in response 
+  if (incentivized) {
+    uri = uri + `&incentivizedStats=${incentivized}`;
   }
 
   // Clone the productIds so we can manipulate it.

--- a/lib/api/statistics.js
+++ b/lib/api/statistics.js
@@ -6,11 +6,11 @@
 const envPrefixMap = {
   qa: 'qa.api',
   staging: 'stg.api',
-  production: 'api'
-}
+  production: 'api',
+};
 
 // Default configuration
-const API_VERSION = 5.4
+const API_VERSION = 5.4;
 const MAX_REQUESTED_IDS = 100;
 
 /**
@@ -48,83 +48,92 @@ const MAX_REQUESTED_IDS = 100;
  * @return {Promise} a promise that will be resolved with the raw results
  *                   from the statistics call.
  */
-function getStatistics ({ productIds, environment, key, type, filters = {} }) {
+function getStatistics({
+  productIds,
+  environment,
+  key,
+  type,
+  showIncentivizedReviews = false,
+  filters = {},
+}) {
   if (!productIds || !Array.isArray(productIds)) {
-    throw new TypeError('productIds must be an array')
+    throw new TypeError('productIds must be an array');
   }
 
-  const envPrefix = envPrefixMap[environment]
+  const envPrefix = envPrefixMap[environment];
   if (!envPrefix) {
-    throw new TypeError(
-      'environment must be \'qa\', \'staging\', or \'production\''
-    )
+    throw new TypeError("environment must be 'qa', 'staging', or 'production'");
   }
 
   if (!key) {
-    throw new TypeError('key must be provided')
+    throw new TypeError('key must be provided');
   }
 
   if (!type || !(type === 'Reviews' || type === 'NativeReviews')) {
-    throw new TypeError('type must be \'Reviews\' or \'NativeReviews\'')
+    throw new TypeError("type must be 'Reviews' or 'NativeReviews'");
   }
 
-  const uri = `https://${envPrefix}.bazaarvoice.com/data/statistics.json` +
-            `?apiversion=${API_VERSION}` +
-            `&passkey=${key}` +
-            `&stats=${type}` +
-            Object.keys(filters)
-              .map(filter => `&filter=${filter}:${filters[filter]}`)
-              .join()
+  const uri =
+    `https://${envPrefix}.bazaarvoice.com/data/statistics.json` +
+    `?apiversion=${API_VERSION}` +
+    `&passkey=${key}` +
+    `&stats=${type}` +
+    `&incentivizedStats=${showIncentivizedReviews}` +
+    Object.keys(filters)
+      .map(filter => `&filter=${filter}:${filters[filter]}`)
+      .join();
 
   // Clone the productIds so we can manipulate it.
-  productIds = [...productIds]
-  const productIdChunks = []
+  productIds = [...productIds];
+  const productIdChunks = [];
 
   if (productIds.length > 100) {
-    console.warn('Requesting more than 100 products is not recommended!')
+    console.warn('Requesting more than 100 products is not recommended!');
   }
 
   while (productIds.length > 0) {
-    productIdChunks.push(productIds.splice(0, MAX_REQUESTED_IDS))
+    productIdChunks.push(productIds.splice(0, MAX_REQUESTED_IDS));
   }
 
   return Promise.all(
-    productIdChunks.map(products => new Promise((resolve, reject) => {
-      const requestUri = `${uri}&filter=ProductId:${products.join(',')}`
-      return fetch(requestUri)
-        .then(response => response.json())
-        .then(json => {
-          // If there are errors in the actual response body (from API)
-          // we need to handle them here.
-          if (json.HasErrors) {
-            let errors = json.Errors
-            // If for some reason errors is empty or doesn't exist,
-            if (!errors || !Array.isArray(errors) || errors.length <= 0) {
-              reject({
-                Message: 'An unknown error occurred.',
-                Code: 'ERROR_UNKNOWN'
-              })
-            }
-            else {
-              // We can reasonably assume that if an error occurred for this
-              // request it should only have a single error response
-              // unlike submission api errors, which have multiples.
-              reject(json.Errors[0])
-            }
-          }
-          else {
-            resolve(json.Results)
-          }
+    productIdChunks.map(
+      products =>
+        new Promise((resolve, reject) => {
+          const requestUri = `${uri}&filter=ProductId:${products.join(',')}`;
+          return fetch(requestUri)
+            .then(response => response.json())
+            .then(json => {
+              // If there are errors in the actual response body (from API)
+              // we need to handle them here.
+              if (json.HasErrors) {
+                let errors = json.Errors;
+                // If for some reason errors is empty or doesn't exist,
+                if (!errors || !Array.isArray(errors) || errors.length <= 0) {
+                  reject({
+                    Message: 'An unknown error occurred.',
+                    Code: 'ERROR_UNKNOWN',
+                  });
+                } else {
+                  // We can reasonably assume that if an error occurred for this
+                  // request it should only have a single error response
+                  // unlike submission api errors, which have multiples.
+                  reject(json.Errors[0]);
+                }
+              } else {
+                resolve(json.Results);
+              }
+            });
         })
-    }))
+    )
   ).then(results => {
     if (results.length === 0) {
-      return results
+      return results;
+    } else {
+      return results.reduce((a, b) => {
+        return a.concat(b);
+      });
     }
-    else {
-      return results.reduce((a,b) => { return a.concat(b) })
-    }
-  })
+  });
 }
 
-module.exports = getStatistics
+module.exports = getStatistics;


### PR DESCRIPTION
## Ticket
[SWAT-5931](https://bits.bazaarvoice.com/jira/browse/SWAT-5931)

## Problem
The ticket [SWAT-5904](https://bits.bazaarvoice.com/jira/browse/SWAT-5904) requires changes in statistics request url to get incentivized content.

## Solution
Updated  **lib/statistics.js** by adding additional query param in request url - **incentivizedStats**

## Verification steps
1. Open locally  [Inline Ratings](https://github.com/bazaarvoice/inline-ratings) repo or install it you do not have it yet.
2. Go to **node_modules/bv-ui-core/lib/api/statistics.js** and update this file according to current changes.
3. Go to **src/util/api.js** on line `46` update results variable declaration by adding new key - **showIncentivizedReviews**.  The whole declaration should look like this:
```
const results = await getStatistics({
      productIds: filteredProductIds,
      environment: this.environment,
      key: this.key,
      filters: this.filters,
      type: 'Reviews',
      showIncentivizedReviews: true
    }); 
```
4. Run `npm run preview` and open localhost:3000 on Chrome browser.
5. Open Network panel in devtools and ensure that the response contains **IncentivizedReviewCount** key:
<img width="1413" alt="Screen Shot 2020-06-01 at 1 48 47 PM" src="https://user-images.githubusercontent.com/12830595/83402411-61c53400-a40f-11ea-80bd-a894ffe21711.png">
