### PR TITLE
Adding a new listener to cookieConsent

### DIFF
--- a/lib/cookie/README.md
+++ b/lib/cookie/README.md
@@ -5,7 +5,7 @@ The cookie module provides methods for interacting with browser cookies.
 ```js
 var cookie = require('bv-ui-core/lib/cookie');
 
-cookie.write('RememberMe', '1', 365);
+cookie.create('RememberMe', '1', 365);
 console.log(cookie.read('RememberMe')); // '1'
 cookie.remove('RememberMe');
 ```

--- a/lib/cookie/index.js
+++ b/lib/cookie/index.js
@@ -79,6 +79,16 @@ module.exports = {
     if (consentPresent) {
       createCookie(name, value, days, domain, secure);
     }
+    cookieConsent.subscribe(name,'add',function (name) {
+      if (cookieConsent.getConsent(name.toString())) {
+        var object ={}
+        object[name]=true
+        createCookie(name,value,days,domain,secure);
+      } 
+      else { 
+        removeCookie(name,domain)
+      }     
+    })
 
     cookieConsent.subscribe(name, 'enable', function () {
       createCookie(name, value, days, domain, secure);

--- a/lib/cookie/index.js
+++ b/lib/cookie/index.js
@@ -79,10 +79,8 @@ module.exports = {
     if (consentPresent) {
       createCookie(name, value, days, domain, secure);
     }
-    cookieConsent.subscribe(name,'add',function (name) {
-      if (cookieConsent.getConsent(name.toString())) {
-        var object ={}
-        object[name]=true
+    cookieConsent.subscribe(name,'add',function (consent) {
+      if (consent) {
         createCookie(name,value,days,domain,secure);
       } 
       else { 

--- a/lib/cookieConsent/README.md
+++ b/lib/cookieConsent/README.md
@@ -30,6 +30,10 @@ cookieConsent.subscribe('cookie3', 'enable', function (data) {});
 // Subscribe to consent 'disable' event. Triggers when a cookie consent is set to false
 var event = cookieConsent.subscribe('cookie3', 'disable', function (data) {});
 
+//to Subscribe to the store we have the subscribeContent method which accepts a callback.
+// This passes the store to the callback function 
+
+
 // Unsubscribe events
 event.unsubscribe();
 

--- a/lib/cookieConsent/README.md
+++ b/lib/cookieConsent/README.md
@@ -30,8 +30,7 @@ cookieConsent.subscribe('cookie3', 'enable', function (data) {});
 // Subscribe to consent 'disable' event. Triggers when a cookie consent is set to false
 var event = cookieConsent.subscribe('cookie3', 'disable', function (data) {});
 
-//to Subscribe to the store we have the subscribeContent method which accepts a callback.
-// This passes the store to the callback function 
+// Subscribe to the store change event. The latest consent store object is passed as parameter to the callback function
 var event = subscribeToConsentStore(function (store){});
 
 // Unsubscribe events

--- a/lib/cookieConsent/README.md
+++ b/lib/cookieConsent/README.md
@@ -32,7 +32,7 @@ var event = cookieConsent.subscribe('cookie3', 'disable', function (data) {});
 
 //to Subscribe to the store we have the subscribeContent method which accepts a callback.
 // This passes the store to the callback function 
-var event = subscribeStore(function (store){});
+var event = subscribeToConsentStore(function (store){});
 
 // Unsubscribe events
 event.unsubscribe();

--- a/lib/cookieConsent/README.md
+++ b/lib/cookieConsent/README.md
@@ -32,7 +32,7 @@ var event = cookieConsent.subscribe('cookie3', 'disable', function (data) {});
 
 //to Subscribe to the store we have the subscribeContent method which accepts a callback.
 // This passes the store to the callback function 
-
+subscribeStore(function (store){});
 
 // Unsubscribe events
 event.unsubscribe();

--- a/lib/cookieConsent/README.md
+++ b/lib/cookieConsent/README.md
@@ -32,7 +32,7 @@ var event = cookieConsent.subscribe('cookie3', 'disable', function (data) {});
 
 //to Subscribe to the store we have the subscribeContent method which accepts a callback.
 // This passes the store to the callback function 
-subscribeStore(function (store){});
+var event = subscribeStore(function (store){});
 
 // Unsubscribe events
 event.unsubscribe();

--- a/lib/cookieConsent/index.js
+++ b/lib/cookieConsent/index.js
@@ -61,7 +61,6 @@ var cookieConsent = (function () {
       else {
         _publish(consentKey, 'change', consentValue);
       }
-      _publishStore()
     }
   }
   /**
@@ -144,9 +143,14 @@ var cookieConsent = (function () {
       if (!(consent && !Array.isArray(consent) && typeof consent === 'object')) {
         throw new TypeError('cookieConsent (setConsent): consent should be an object.')
       }
+      var store 
       var keys = Object.keys(consent);
       for (var i = 0; i < keys.length; i++) {
         _set(keys[i], consent[keys[i]]);
+      }
+      var storeCopy=Object.assign({},store)
+      if (JSON.stringify(storeCopy)!==JSON.stringify(store)) {
+        _publishStore()
       }
       return true;
     }

--- a/lib/cookieConsent/index.js
+++ b/lib/cookieConsent/index.js
@@ -25,10 +25,10 @@ var cookieConsent = (function () {
    * _publishStore: calls Callbacks with the store object passed
    */
 
-  function _publishStore(){
-    if(Object.values(storeCallbacks).length>0){
-      var storeCopy = Object.assign({},store)
-      Object.values(storeCallbacks).forEach(function (callback){
+  function _publishStore () {
+    if (Object.values(storeCallbacks).length > 0) {
+      var storeCopy = Object.assign({}, store)
+      Object.values(storeCallbacks).forEach(function (callback) {
         callback(storeCopy)
       })
     }
@@ -77,8 +77,8 @@ var cookieConsent = (function () {
   /**
    * _unsubscribeStore: Unsubscribes subscribers from the consent store 
    */
-  function _unsubscribeStore(){
-    if(storeCallbacks[this.key]){
+  function _unsubscribeStore () {
+    if (storeCallbacks[this.key]) {
       delete storeCallbacks[this.key];
     }
   }
@@ -198,16 +198,16 @@ var cookieConsent = (function () {
     };
   }
 
-  function subscribeToConsentStore(callback) {
+  function subscribeToConsentStore (callback) {
     if (typeof callback !== 'function') {
       throw new TypeError('cookieConsent (subscribeToConsentStore): callback should be a function.');
     }
-    
-    var key = Math.random().toString(36).substr(2,5);
+
+    var key = Math.random().toString(36).substr(2, 5);
     storeCallbacks[key] = callback;
 
     return {
-      unsubscribe: _unsubscribeStore.bind({key:key})
+      unsubscribe: _unsubscribeStore.bind({ key: key })
     }
   }
 

--- a/lib/cookieConsent/index.js
+++ b/lib/cookieConsent/index.js
@@ -189,6 +189,11 @@ var cookieConsent = (function () {
       throw new TypeError('cookieConsent (subscribe): callback should be a function.');
     }
     storeCallback = callback;
+    return {
+      unsubscribe: function () {
+        storeCallback = undefined
+      }
+    }
   }
 
   return {

--- a/lib/cookieConsent/index.js
+++ b/lib/cookieConsent/index.js
@@ -27,8 +27,8 @@ var cookieConsent = (function () {
 
   function _publishStore () {
     if (Object.values(storeCallbacks).length > 0) {
-      var storeCopy = Object.assign({}, store)
       Object.values(storeCallbacks).forEach(function (callback) {
+        var storeCopy = Object.assign({}, store)
         callback(storeCopy)
       })
     }

--- a/lib/cookieConsent/index.js
+++ b/lib/cookieConsent/index.js
@@ -28,8 +28,7 @@ var cookieConsent = (function () {
   function _publishStore () {
     if (Object.values(storeCallbacks).length > 0) {
       Object.values(storeCallbacks).forEach(function (callback) {
-        var storeCopy = Object.assign({}, store)
-        callback(storeCopy)
+        callback(Object.assign({}, store));
       })
     }
   }

--- a/lib/cookieConsent/index.js
+++ b/lib/cookieConsent/index.js
@@ -4,7 +4,7 @@ var cookieConsent = (function () {
   var store = {};
   var subscribers = {};
   var events = ['add', 'enable', 'disable', 'change'];
-  var storeCallback = undefined;
+  var storeCallbacks = {};
 
 
   /**
@@ -17,6 +17,19 @@ var cookieConsent = (function () {
     if (subscribers[consentKey] && subscribers[consentKey][eventName]) {
       Object.values(subscribers[consentKey][eventName]).forEach(function (callback) {
         callback(data);
+      })
+    }
+  }
+
+  /**
+   * _publishStore: calls Callbacks with the store object passed
+   */
+
+  function _publishStore(){
+    if(Object.values(storeCallbacks).length>0){
+      var storeCopy = Object.assign({},store)
+      Object.values(storeCallbacks).forEach(function (callback){
+        callback(storeCopy)
       })
     }
   }
@@ -37,27 +50,19 @@ var cookieConsent = (function () {
 
       if (oldValue === undefined) {
         _publish(consentKey, 'add', consentValue);
-        if (storeCallback) {
-          storeCallback(store)
-        }
       }
       if (oldValue === true) {
         _publish(consentKey, 'disable', consentValue);
         _publish(consentKey, 'change', consentValue);
-        if (storeCallback) {
-          storeCallback(store)
-        }
       }
       else if (oldValue === false) {
         _publish(consentKey, 'enable', consentValue);
         _publish(consentKey, 'change', consentValue);
-        if (storeCallback) {
-          storeCallback(store)
-        }
       }
       else {
         _publish(consentKey, 'change', consentValue);
       }
+      _publishStore()
     }
   }
   /**
@@ -66,6 +71,15 @@ var cookieConsent = (function () {
   function _unsubscribe () {
     if (subscribers[this.consentKey] && subscribers[this.consentKey][this.eventName]) {
       delete subscribers[this.consentKey][this.eventName][this.key];
+    }
+  }
+
+  /**
+   * _unsubscribeStore: Unsubscribes subscribers from the consent store 
+   */
+  function _unsubscribeStore(){
+    if(storeCallbacks[this.key]){
+      delete storeCallbacks[this.key];
     }
   }
   /**
@@ -184,15 +198,16 @@ var cookieConsent = (function () {
     };
   }
 
-  var subscribeConsent = function (callback) {
+  function subscribeToConsentStore(callback) {
     if (typeof callback !== 'function') {
-      throw new TypeError('cookieConsent (subscribe): callback should be a function.');
+      throw new TypeError('cookieConsent (subscribeToConsentStore): callback should be a function.');
     }
-    storeCallback = callback;
+    
+    var key = Math.random().toString(36).substr(2,5);
+    storeCallbacks[key] = callback;
+
     return {
-      unsubscribe: function () {
-        storeCallback = undefined
-      }
+      unsubscribe: _unsubscribeStore.bind({key:key})
     }
   }
 
@@ -202,7 +217,7 @@ var cookieConsent = (function () {
     getConsentDisabled: getConsentDisabled,
     setConsent: setConsent,
     subscribe: subscribe,
-    subscribeConsent: subscribeConsent
+    subscribeToConsentStore: subscribeToConsentStore
   };
 })();
 

--- a/lib/cookieConsent/index.js
+++ b/lib/cookieConsent/index.js
@@ -4,6 +4,9 @@ var cookieConsent = (function () {
   var store = {};
   var subscribers = {};
   var events = ['add', 'enable', 'disable', 'change'];
+  var storeCallback = undefined;
+
+
   /**
    * _publish: Calls subscriber callbacks
    * @param {String} consentKey Consent key
@@ -34,14 +37,23 @@ var cookieConsent = (function () {
 
       if (oldValue === undefined) {
         _publish(consentKey, 'add', consentValue);
+        if (storeCallback) {
+          storeCallback(store)
+        }
       }
       if (oldValue === true) {
         _publish(consentKey, 'disable', consentValue);
         _publish(consentKey, 'change', consentValue);
+        if (storeCallback) {
+          storeCallback(store)
+        }
       }
       else if (oldValue === false) {
         _publish(consentKey, 'enable', consentValue);
         _publish(consentKey, 'change', consentValue);
+        if (storeCallback) {
+          storeCallback(store)
+        }
       }
       else {
         _publish(consentKey, 'change', consentValue);
@@ -172,12 +184,20 @@ var cookieConsent = (function () {
     };
   }
 
+  var subscribeConsent = function (callback) {
+    if (typeof callback !== 'function') {
+      throw new TypeError('cookieConsent (subscribe): callback should be a function.');
+    }
+    storeCallback = callback;
+  }
+
   return {
     initConsent: initConsent,
     getConsent: getConsent,
     getConsentDisabled: getConsentDisabled,
     setConsent: setConsent,
-    subscribe: subscribe
+    subscribe: subscribe,
+    subscribeConsent: subscribeConsent
   };
 })();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.5.2",
+  "version": "2.6.0",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {

--- a/test/unit/cookieConsent/index.spec.js
+++ b/test/unit/cookieConsent/index.spec.js
@@ -90,7 +90,7 @@ describe('lib/cookieConsent', function () {
     function test6 () {
       cookieConsent.subscribeToConsentStore('Callback')
     }
-    expect(test6()).to.throw(TypeError,'cookieConsent (subscribeToConsentStore): callback should be a function.');
+    expect(test6).to.throw(TypeError,'cookieConsent (subscribeToConsentStore): callback should be a function.');
 
     function test7 () {
       return cookieConsent.subscribeToConsentStore(function () {});

--- a/test/unit/cookieConsent/index.spec.js
+++ b/test/unit/cookieConsent/index.spec.js
@@ -84,20 +84,21 @@ describe('lib/cookieConsent', function () {
     function test5 () {
       return cookieConsent.subscribe('key1', 'enable', function () {});
     }
-
     expect(test5()).to.be.an('object');
-    //Error Test
+  });
+  it('cookieConsent.subscribeToConsentStore', function () {
+    // Error checks - Correct errors are thrown
     function test6 () {
       cookieConsent.subscribeToConsentStore('Callback')
     }
     expect(test6).to.throw(TypeError,'cookieConsent (subscribeToConsentStore): callback should be a function.');
-    //ConsentCallback Creator Test
+    // Subscriber creation test - The subscription gets created correctly
     function test7 () {
       return cookieConsent.subscribeToConsentStore(function () {});
     }
     expect(test7()).to.be.an('object');
 
-    //Event Listener Test
+    // Event listener test - The subscriber callback fires on store change
     var fn = sinon.spy()
     function test8 () {
       cookieConsent.subscribeToConsentStore(fn)
@@ -105,8 +106,7 @@ describe('lib/cookieConsent', function () {
     }
     test8 ()
     sinon.assert.calledOnce(fn)
-
-    //Unsubscribe Test
+    // Unsubscribe test - Should be able to unsubscribe successfully (Should not fire the callback after unsubscription)
     var fn2 = sinon.spy()
     function test9 () {
       var event = cookieConsent.subscribeToConsentStore(fn2)
@@ -115,6 +115,5 @@ describe('lib/cookieConsent', function () {
     } 
     test9()
     sinon.assert.notCalled(fn2)
-
   });
 });

--- a/test/unit/cookieConsent/index.spec.js
+++ b/test/unit/cookieConsent/index.spec.js
@@ -86,5 +86,15 @@ describe('lib/cookieConsent', function () {
     }
 
     expect(test5()).to.be.an('object');
+
+    function test6(){
+      cookieConsent.subscribeToConsentStore('Callback')
+    }
+    expect(test6()).to.throw(TypeError,'cookieConsent (subscribeToConsentStore): callback should be a function.');
+
+    function test7(){
+      return cookieConsent.subscribeToConsentStore(function () {});
+    }
+    expect(test7()).to.be.an('object');
   });
 });

--- a/test/unit/cookieConsent/index.spec.js
+++ b/test/unit/cookieConsent/index.spec.js
@@ -87,12 +87,12 @@ describe('lib/cookieConsent', function () {
 
     expect(test5()).to.be.an('object');
 
-    function test6(){
+    function test6 () {
       cookieConsent.subscribeToConsentStore('Callback')
     }
     expect(test6()).to.throw(TypeError,'cookieConsent (subscribeToConsentStore): callback should be a function.');
 
-    function test7(){
+    function test7 () {
       return cookieConsent.subscribeToConsentStore(function () {});
     }
     expect(test7()).to.be.an('object');

--- a/test/unit/cookieConsent/index.spec.js
+++ b/test/unit/cookieConsent/index.spec.js
@@ -86,15 +86,35 @@ describe('lib/cookieConsent', function () {
     }
 
     expect(test5()).to.be.an('object');
-
+    //Error Test
     function test6 () {
       cookieConsent.subscribeToConsentStore('Callback')
     }
     expect(test6).to.throw(TypeError,'cookieConsent (subscribeToConsentStore): callback should be a function.');
-
+    //ConsentCallback Creator Test
     function test7 () {
       return cookieConsent.subscribeToConsentStore(function () {});
     }
     expect(test7()).to.be.an('object');
+
+    //Event Listener Test
+    var fn = sinon.spy()
+    function test8 () {
+      cookieConsent.subscribeToConsentStore(fn)
+      cookieConsent.setConsent({ cookie4: true })
+    }
+    test8 ()
+    sinon.assert.calledOnce(fn)
+
+    //Unsubscribe Test
+    var fn2 = sinon.spy()
+    function test9 () {
+      var event = cookieConsent.subscribeToConsentStore(fn2)
+      event.unsubscribe()
+      cookieConsent.setConsent({ cookie5: true })
+    } 
+    test9()
+    sinon.assert.notCalled(fn2)
+
   });
 });


### PR DESCRIPTION
# PR description

<!--Mention the JIRA ticket numbers below-->

## JIRA tickets

[PD-177966](https://bazaarvoice.atlassian.net/browse/PD-177966)
[PD-177967](https://bazaarvoice.atlassian.net/browse/PD-177967)


<!--Please mention if the PR is for a feature or bug. Select both if it contains both-->

## This PR is for

- Feature

<!--Mention the requirements / issues in points-->

## Requirements / issues

-  Cookie module should listen to the add consent event when it creates a cookie
- Cookie consent module should have a function which passes the entire consent object to a callback whenever there is any change in the consent 

<!--Mention the steps taken to solve each of the above points-->

## Solutions

- subscribed to the add event in the cookie module when creating a cookie 
- Exposed a new method called subscribeStore. Which accepts a callback function and passes the store object as the param ameter


<!--Mention the test suit definations added-->

## Test cases summary

- Existing test cases work 

<!--Mention steps for QA testing in points-->

## Steps to verify

- Use the new module and run the subscribeStore command to test it out