### PR TITLE
PD-205376 - Added utility method to get bv container elements from open shadow dom.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "env": {
     "node": true,
-    "browser": true
+    "browser": true,
+    "es6": true
   },
   "rules": {
     "brace-style": [2, "stroustrup", { "allowSingleLine": true }],

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ module's directory.
 - [pixelsDisplayed](./lib/pixelsDisplayed)
 - [staticAssetLoader](./lib/staticAssetLoader)
 - [waitForBody](./lib/waitForBody)
+- [queryShadowDom](./lib/queryShadowDom)
 
 [1]: ./CONTRIBUTING.md
 [2]: https://nodejs.org/download/

--- a/lib/queryShadowDom/README.md
+++ b/lib/queryShadowDom/README.md
@@ -8,8 +8,8 @@ This file exposes multiple functions that can be used to query elements within t
 ```
 | Parameter | Type     | Description                |
 | :-------- | :------- | :------------------------- |
-| `element` | `DOM Element` | **Required**. Root element to query for particular elements. |
-| `matchSelector` | `string` | **Required**. Criteria to select the elements in the dom starting with element as root element. |
+| `node` | `DOM Element` | **Required**. Root node to query for particular elements. |
+| `matchSelector` | `string` | **Required**. Criteria to select the elements in the dom starting with node as root element. |
 
 
 ```javascript
@@ -18,7 +18,7 @@ This file exposes multiple functions that can be used to query elements within t
 ```
 | Parameter | Type     | Description                |
 | :-------- | :------- | :------------------------- |
-| `rootElement` | `DOM Element` | **Required**. The root element from which to start searching for shadow roots. |
+| `node` | `DOM Element` | **Required**. The root node from which to start searching for shadow roots. |
 
 ```javascript
   filterShadowHosts
@@ -34,8 +34,8 @@ This file exposes multiple functions that can be used to query elements within t
 ```
 | Parameter | Type     | Description                |
 | :-------- | :------- | :------------------------- |
-| `shadowElement` | `DOM Element` | **Required**. A DOM element that has a shadow root. |
-| `matchSelector` | `string` | **Required**. Criteria to select the elements in the dom starting with element as root element. |
+| `node` | `DOM Element` | **Required**. A DOM node that has a shadow root. |
+| `matchSelector` | `string` | **Required**. Criteria to select the elements in the dom starting with node as root element. |
 
 ## Usage
 

--- a/lib/queryShadowDom/README.md
+++ b/lib/queryShadowDom/README.md
@@ -1,0 +1,50 @@
+# Query Shadow DOM Element
+
+This file exposes multiple functions that can be used to query elements within the ShadowDOM. 
+
+```javascript
+  shadowQuerySelectorAll
+  // Returns Nodes matching with match selector.
+```
+| Parameter | Type     | Description                |
+| :-------- | :------- | :------------------------- |
+| `element` | `DOM Element` | **Required**. Root element to query for particular elements. |
+| `matchSelector` | `string` | **Required**. Criteria to select the elements in the dom starting with element as root element. |
+
+
+```javascript
+  findShadowRoots
+  // Returns a list of all the shadow roots found in the given root element and its descendants.
+```
+| Parameter | Type     | Description                |
+| :-------- | :------- | :------------------------- |
+| `rootElement` | `DOM Element` | **Required**. The root element from which to start searching for shadow roots. |
+
+```javascript
+  filterShadowHosts
+  // Returns NodeFilter.
+```
+| Parameter | Type     | Description                |
+| :-------- | :------- | :------------------------- |
+| `node` | `DOM Element` | **Required**. Document node. |
+
+```javascript
+  findElementsInShadowDomByMatchSector
+  // returns a NodeList of all elements within the shadow DOM of the shadowElement parameter that match the matchSelector parameter.
+```
+| Parameter | Type     | Description                |
+| :-------- | :------- | :------------------------- |
+| `shadowElement` | `DOM Element` | **Required**. A DOM element that has a shadow root. |
+| `matchSelector` | `string` | **Required**. Criteria to select the elements in the dom starting with element as root element. |
+
+## Usage
+
+```javascript
+
+
+const { shadowQuerySelectorAll } = require('bv-ui-core/lib/queryShadowDomElement');
+
+const nodeList = shadowQuerySelectorAll(document, '[data-bv-show='reviews']')
+
+// ['div', 'div']
+```

--- a/lib/queryShadowDom/index.js
+++ b/lib/queryShadowDom/index.js
@@ -51,8 +51,9 @@ function findShadowRoots (rootElement) {
  */
 
 function findElementsInShadowDomByMatchSector (shadowElement, matchSelector) {
-  const el = shadowElement.shadowRoot;
-  return el.querySelectorAll(matchSelector); 
+  if (shadowElement && shadowElement.shadowRoot && matchSelector) {
+    return shadowElement.shadowRoot.querySelectorAll(matchSelector)
+  }
 }
 
 /**
@@ -62,6 +63,13 @@ function findElementsInShadowDomByMatchSector (shadowElement, matchSelector) {
  * @returns Nodes matching with match selector.
  */
 function shadowQuerySelectorAll (element, matchSelector) {
+
+  /* Checks if both `element` and `matchSelector` are truthy values. If either of
+  them is falsy, it throws an error. */
+  if (!(element && matchSelector)) {
+    throw new Error(`Unable to find ${element} or ${matchSelector}`)
+  }
+
   // Get the elements by query selector all.
   const nodeList = element.querySelectorAll(matchSelector);
   const shadowRoots = findShadowRoots(element);

--- a/lib/queryShadowDom/index.js
+++ b/lib/queryShadowDom/index.js
@@ -4,7 +4,7 @@
 * @returns NodeFilter 
 */
 function filterShadowHosts (node) {
-  if (node.shadowRoot) {
+  if (node && node.shadowRoot) {
     return NodeFilter.FILTER_ACCEPT;
   }
   return NodeFilter.FILTER_SKIP;
@@ -12,22 +12,22 @@ function filterShadowHosts (node) {
 
 /**
  * The function finds all the shadow roots in a given root element and returns a list of them.
- * @param rootElement - The root element from which to start searching for shadow roots.
+ * @param node - The root element from which to start searching for shadow roots.
  * @returns a list of all the shadow roots found in the given root element and its descendants.
  */
-function findShadowRoots (rootElement) {
+function findShadowRoots (node) {
   
-  if (!rootElement) {
+  if (!node) {
     return;
   }
 
-  const walker = document.createTreeWalker(rootElement, NodeFilter.SHOW_ELEMENT, filterShadowHosts);
+  const walker = document.createTreeWalker(node, NodeFilter.SHOW_ELEMENT, filterShadowHosts);
   let listOfShadowRoots = [];
   
-  // Tree walker will not determine the rootElement. 
-  if (rootElement.shadowRoot) {
-    listOfShadowRoots.push(rootElement);
-    listOfShadowRoots = listOfShadowRoots.concat(findShadowRoots(rootElement.shadowRoot));
+  // Tree walker will not determine the node. 
+  if (node.shadowRoot) {
+    listOfShadowRoots.push(node);
+    listOfShadowRoots = listOfShadowRoots.concat(findShadowRoots(node.shadowRoot));
   }
 
   // Traverse all the nodes.
@@ -44,35 +44,35 @@ function findShadowRoots (rootElement) {
 
 /**
  * This function finds elements within a shadow DOM that match a given selector.
- * @param shadowElement - A DOM element that has a shadow root. 
+ * @param node - A DOM element that has a shadow root. 
  * @param matchSelector - Criteria to select the elements in the dom starting with element as root element.
  * @returns The function `findElementsInShadowDomByMatchSector` returns a NodeList of all elements
  * within the shadow DOM of the `shadowElement` parameter that match the `matchSelector` parameter.
  */
 
-function findElementsInShadowDomByMatchSector (shadowElement, matchSelector) {
-  if (shadowElement && shadowElement.shadowRoot && matchSelector) {
-    return shadowElement.shadowRoot.querySelectorAll(matchSelector)
+function findElementsInShadowDomByMatchSector (node, matchSelector) {
+  if (node && node.shadowRoot && matchSelector) {
+    return node.shadowRoot.querySelectorAll(matchSelector)
   }
 }
 
 /**
  * Finds elements in the DOM including open shadowDOM.
- * @param {*} element Root element to query for particular elements 
+ * @param {*} node Root element to query for particular elements 
  * @param {*} matchSelector Criteria to select the elements in the dom starting with element as root element.
  * @returns Nodes matching with match selector.
  */
-function shadowQuerySelectorAll (element, matchSelector) {
+function shadowQuerySelectorAll (node, matchSelector) {
 
   /* Checks if both `element` and `matchSelector` are truthy values. If either of
   them is falsy, it throws an error. */
-  if (!(element && matchSelector)) {
-    throw new Error(`Unable to find ${element} or ${matchSelector}`)
+  if (!(node && matchSelector)) {
+    throw new Error(`Unable to find ${node} or ${matchSelector}`)
   }
 
   // Get the elements by query selector all.
-  const nodeList = element.querySelectorAll(matchSelector);
-  const shadowRoots = findShadowRoots(element);
+  const nodeList = node.querySelectorAll(matchSelector);
+  const shadowRoots = findShadowRoots(node);
   let elements = [];
 
   for (const rootElement of shadowRoots) {

--- a/lib/queryShadowDom/index.js
+++ b/lib/queryShadowDom/index.js
@@ -1,0 +1,85 @@
+/**
+* Function to deterimine whether given node is shadow host. 
+* @param {*} node Document node.
+* @returns NodeFilter 
+*/
+function filterShadowHosts (node) {
+  if (node.shadowRoot) {
+    return NodeFilter.FILTER_ACCEPT;
+  }
+  return NodeFilter.FILTER_SKIP;
+}
+
+/**
+ * The function finds all the shadow roots in a given root element and returns a list of them.
+ * @param rootElement - The root element from which to start searching for shadow roots.
+ * @returns a list of all the shadow roots found in the given root element and its descendants.
+ */
+function findShadowRoots (rootElement) {
+  
+  if (!rootElement) {
+    return;
+  }
+
+  const walker = document.createTreeWalker(rootElement, NodeFilter.SHOW_ELEMENT, filterShadowHosts);
+  let listOfShadowRoots = [];
+  
+  // Tree walker will not determine the rootElement. 
+  if (rootElement.shadowRoot) {
+    listOfShadowRoots.push(rootElement);
+    listOfShadowRoots = listOfShadowRoots.concat(findShadowRoots(rootElement.shadowRoot));
+  }
+
+  // Traverse all the nodes.
+  while (walker.nextNode()) {
+    listOfShadowRoots.push(walker.currentNode);
+
+    if (walker.currentNode.shadowRoot) {
+      listOfShadowRoots = listOfShadowRoots.concat(findShadowRoots(walker.currentNode.shadowRoot));
+    }
+  
+  }
+  return listOfShadowRoots;
+}
+
+/**
+ * This function finds elements within a shadow DOM that match a given selector.
+ * @param shadowElement - A DOM element that has a shadow root. 
+ * @param matchSelector - Criteria to select the elements in the dom starting with element as root element.
+ * @returns The function `findElementsInShadowDomByMatchSector` returns a NodeList of all elements
+ * within the shadow DOM of the `shadowElement` parameter that match the `matchSelector` parameter.
+ */
+
+function findElementsInShadowDomByMatchSector (shadowElement, matchSelector) {
+  const el = shadowElement.shadowRoot;
+  return el.querySelectorAll(matchSelector); 
+}
+
+/**
+ * Finds elements in the DOM including open shadowDOM.
+ * @param {*} element Root element to query for particular elements 
+ * @param {*} matchSelector Criteria to select the elements in the dom starting with element as root element.
+ * @returns Nodes matching with match selector.
+ */
+function shadowQuerySelectorAll (element, matchSelector) {
+  // Get the elements by query selector all.
+  const nodeList = element.querySelectorAll(matchSelector);
+  const shadowRoots = findShadowRoots(element);
+  let elements = [];
+
+  for (const rootElement of shadowRoots) {
+    const filteredElements = findElementsInShadowDomByMatchSector(rootElement, matchSelector);
+    if (filteredElements.length > 0) {
+      elements.push(...filteredElements);
+    }
+  }
+
+  return [...nodeList, ...elements];
+}
+
+module.exports = {
+  findShadowRoots,
+  filterShadowHosts,
+  shadowQuerySelectorAll,
+  findElementsInShadowDomByMatchSector
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {


### PR DESCRIPTION
# PR description

<!--Mention the JIRA ticket numbers below-->

## JIRA tickets

[PD-205376](https://bazaarvoice.atlassian.net/browse/PD-205376)

<!--Please mention if the PR is for a feature or bug. Select both if it contains both-->

## This PR is for

- Feature 

<!--Mention the requirements / issues in points-->

## Requirements / issues

Added utility method to get bv container elements from open shadow dom.

<!--Mention the steps taken to solve each of the above points-->

## Solutions

- Added utility method to get bv container elements from open shadow dom.

## Methods

1. `shadowQuerySelectorAll` - `(node, matchSelector)` - Returns Nodes matching with match selector.
2. `findShadowRoots` - `(node)` - Returns a list of all the shadow roots found in the given root element and its descendants.
3. `filterShadowHosts` - `(node)` - Returns NodeFilter.
4. `findElementsInShadowDomByMatchSector` - `(node, matchSelector)` - Returns a NodeList of all elements within the shadow DOM of the shadowElement parameter that match the matchSelector parameter.

<!-- Mention all the unit tests written -->

<!--## Unit tests-->

<!--Mention steps for QA testing in points-->

## Steps to verify

- using npm link to test the changes in local in bv-loader

## Check points

<!-- Design/approach documented in confluence and in the story -->

- [x] Functionality
<!-- UI/UX validation (Get UI/UX validated by designer) -->
<!-- Unit test cases -->

## Version 
This will be released as a new minor version as we are adding a new module 


[PD-205376]: https://bazaarvoice.atlassian.net/browse/PD-205376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ