### PR TITLE
[utility fix] fix issue when global is polluted

### DIFF
--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -19,7 +19,21 @@ var getGlobal = function () {
     global import in all bundle use cases
   */
   if (globalObj && globalObj.__esModule) {
-    globalObj.default = Object.assign({}, globalObj)
+    const override = {
+      get: function (target, prop) {
+        if (prop === 'default') {
+          return target
+        }
+
+        return target[prop]
+      },
+
+      set: function (target, prop, value) {
+        target[prop] = value
+      },
+    };
+    const proxyGlobal = new Proxy(globalObj, override)
+    return proxyGlobal
   }
   return globalObj
 };

--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -20,16 +20,16 @@ var getGlobal = function () {
   */
   if (globalObj && globalObj.__esModule) {
     const override = {
-      get: function (target, prop) {
+      get: function (target, prop, receiver) {
         if (prop === 'default') {
           return target
         }
 
-        return target[prop]
+        return Reflect.get(receiver, prop, target)
       },
 
       set: function (target, prop, value) {
-        target[prop] = value
+        Reflect.set(target, prop, value)
       },
     };
     const proxyGlobal = new Proxy(globalObj, override)

--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -6,11 +6,22 @@
 'use strict'; /* eslint strict:0 */
 
 var getGlobal = function () {
-  if (typeof globalThis !== 'undefined') { return globalThis; }
-  if (typeof window !== 'undefined') { return window; }
-  if (typeof self !== 'undefined') { return self; }
-  if (typeof global !== 'undefined') { return global; }
-  throw new Error('unable to locate global object');
+  var globalObj = (function () {
+    if (typeof globalThis !== 'undefined') { return globalThis; }
+    if (typeof window !== 'undefined') { return window; }
+    if (typeof self !== 'undefined') { return self; }
+    if (typeof global !== 'undefined') { return global; }
+    throw new Error('unable to locate global object');
+  })()
+  /*
+    The below code was added in case there is pollution in global namespace
+    windows object during transpilation with __esModule being set. Below code would support
+    global import in all bundle use cases
+  */
+  if (globalObj && globalObj.__esModule) {
+    globalObj.default = Object.assign({}, globalObj)
+  }
+  return globalObj
 };
 
 module.exports = getGlobal();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {

--- a/test/unit/global/index.spec.js
+++ b/test/unit/global/index.spec.js
@@ -15,4 +15,13 @@ describe('lib/global', function () {
     }
   });
 
+  it('should export window with default pointing to windows if __esModule is set', function () {
+    // If we have access to the window object, compare against it.
+    if (typeof window !== 'undefined') {
+      window.__esModule = true
+      var global = require('../../../lib/global')
+      expect(global).to.eql(window);
+    }
+  });
+
 });


### PR DESCRIPTION
# PR description

<!--Mention the JIRA ticket numbers below-->

## JIRA tickets

[PD-215136](https://bazaarvoice.atlassian.net/browse/PD-215136)
[Approach document](https://bazaarvoice.atlassian.net/wiki/spaces/DEV/pages/edit-v2/78462714460)

<!--Please mention if the PR is for a feature or bug. Select both if it contains both-->

## This PR is for

- Bug

<!--Mention the requirements / issues in points-->

## Requirements / issues

- When a client uses transpilations for its esModule files with default exports, these transpilations sets __esModule to true to each of such module. For Example: If the client has a esModule which exports globalThis/global/window object by default. It sets __esModule to true, to value after resolution of the modulie, in this case, window.__esModule is set
- SWAT apps uses webpack as bundler, webpack adds logic to import such default export esModule's by a condition, if esModule is set, then return module's default.
- This causes issue as this tries to return windows.default , which do not exist, when importing global.js 

<!--Mention the steps taken to solve each of the above points-->

## Solutions

- Added a straightforward check for the same global object for __esModule, if set add create proxy object to whatever is returned
- Add getters and setter for this object.
- For getter, add a special case to check default, if requested, return the same object

<!-- Mention all the unit tests written -->

## Unit tests

- Global object
  - should export window with default pointing to windows if __esModule is set

<!--Mention steps for QA testing in points-->

## Version

- Patch - 2.8.1

[PD-215136]: https://bazaarvoice.atlassian.net/browse/PD-215136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ