### PR TITLE
fix: added boolean return for global set to fix Proxy set trapped error

### DIFF
--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -30,6 +30,7 @@ var getGlobal = function () {
 
       set: function (target, prop, value) {
         Reflect.set(target, prop, value)
+        return true
       },
     };
     const proxyGlobal = new Proxy(globalObj, override)

--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -28,8 +28,8 @@ var getGlobal = function () {
         return Reflect.get(receiver, prop, target)
       },
 
-      set: function (target, prop, value) {
-        Reflect.set(target, prop, value)
+      set: function (target, prop, value, receiver) {
+        Reflect.set(target, prop, value, receiver)
         return true
       },
     };

--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -19,21 +19,20 @@ var getGlobal = function () {
     global import in all bundle use cases
   */
   if (globalObj && globalObj.__esModule) {
-    const override = {
-      get: function (target, prop, receiver) {
+    const proxyGlobal = new Proxy(globalObj, {
+      get: function (target, prop) {
         if (prop === 'default') {
           return target
         }
 
-        return Reflect.get(receiver, prop, target)
+        return target[prop]
       },
 
-      set: function (target, prop, value, receiver) {
-        Reflect.set(target, prop, value, receiver)
+      set: function (target, prop, value) {
+        target[prop] = value
         return true
       },
-    };
-    const proxyGlobal = new Proxy(globalObj, override)
+    })
     return proxyGlobal
   }
   return globalObj

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {


### PR DESCRIPTION
# PR description

<!--Mention the JIRA ticket numbers below-->

## JIRA tickets

[PD-215136](https://bazaarvoice.atlassian.net/browse/PD-215136)

<!--Please mention if the PR is for a feature or bug. Select both if it contains both-->

## This PR is for

- Bug

<!--Mention the requirements / issues in points-->

## Requirements / issues

- BV loader throws ''set' on proxy: trap returned falsish for property javascript' error when latest global of bv-ui-core
- This is because, BV namespace has its own proxy and a setter which tries to set properties to window.BV
- global do not return any boolean in its setter method - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set#return_value


<!--Mention the steps taken to solve each of the above points-->

## Solutions

- Add boolean return for global's return method

<!-- Mention all the unit tests written -->

## Unit tests

- N/A

<!--Mention steps for QA testing in points-->

## Version

- Patch - 2.8.2

[PD-215136]: https://bazaarvoice.atlassian.net/browse/PD-215136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ