### PR TITLE
PD-234259: TraegerService: Console error "Remove Child"

### DIFF
--- a/lib/loader/index.js
+++ b/lib/loader/index.js
@@ -152,8 +152,9 @@ module.exports = {
       done = true;
       clearTimeout(timeoutHandle);
       script.onload = script.onreadystatechange = script.onerror = null;
-      script.parentNode.removeChild(script);
-
+      if (script && script.parentNode) {
+        script.parentNode.removeChild(script);
+      }
       if (!err) {
         _loadedUrls[url] = true;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {


### PR DESCRIPTION
 <!-- Replace XXX with the number of the JIRA ticket. -->
[PD-234259](https://bazaarvoice.atlassian.net/browse/PD-234259)

## This PR is for

- Bug

## Problem/Goal
The client is seeing an error in the console "Uncaught TypeError: Cannot read properties of null (reading 'removeChild')"


## Solution
As a fix now we are adding a condition if script is having parent node then we are allowing to remove the child by doing so it will not throw any error in the console.

**Before fix**

<img width="1718" alt="Screenshot 2024-03-25 at 11 26 15 AM" src="https://github.com/bazaarvoice/bv-ui-core/assets/64261454/4ef9bc99-f105-448e-a740-c54f84bfc902">



**After fix:**
 
<img width="1716" alt="Screenshot 2024-03-25 at 11 24 11 AM" src="https://github.com/bazaarvoice/bv-ui-core/assets/64261454/331dfdeb-6af0-4529-a202-1c24cb204f4c">

Note: console error which is observed because clients are on lower version and we used redirection for testing so.

[PD-234259]: https://bazaarvoice.atlassian.net/browse/PD-234259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ