### PR TITLE
returning cloned promise for bvFetch module

### DIFF
--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -53,7 +53,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName }) {
 
         // check if there is an ongoing promise
         if (this.fetchPromises.has(cacheKey)) {
-          return this.fetchPromises.get(cacheKey);
+          return this.fetchPromises.get(cacheKey).then(res => res.clone());
         }
 
         // Make a new call


### PR DESCRIPTION
<!-- Replace XXX with the number of the JIRA ticket. -->
[PD-230727](https://bazaarvoice.atlassian.net/browse/PD-230727)

## Problem/Goal

Creating bvFetch module whose purpose is to cache duplicate api calls. Need to resolve error `Error: TypeError: Already read`

## Solution

Created the module which caches the api responses based on the url. 
Made change to return cloned promise to fix the error.

[PD-230727]: https://bazaarvoice.atlassian.net/browse/PD-230727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ