### PR TITLE
adding cache expiry mechanisms and fixing PD-237465, PD-237445

### DIFF
--- a/lib/bvFetch/README.md
+++ b/lib/bvFetch/README.md
@@ -18,6 +18,25 @@ The BvFetch module provides methods to cache duplicate API calls and interact wi
 ## bvFetchFunc Return Value
 `Promise<Response>:` A promise that resolves to the API response. If the response is cached, it returns the cached response. Otherwise, it fetches data from the API endpoint, caches the response according to the caching logic, and returns the fetched response.
 
+## generateCacheKey Method Parameters:
+`url (String):` The URL of the API endpoint.
+`options (Object):` Optional request options.
+
+## generateCacheKey Return Value:
+`string:` The generated cache key.
+
+## updateCacheSize Method Parameters:
+`sizeChange (number):` The change in cache size.
+
+## updateCacheSize Return Value: 
+This function does not return anything.
+
+## retrieveCacheSize Method Parameters: 
+This function does not accept any parameters.
+
+## retrieveCacheSize Return Value:
+Promise<number>: A promise that resolves to the retrieved cache size.
+
 ## flushCache Method Parameters
 This method takes no parameters.
 

--- a/lib/bvFetch/README.md
+++ b/lib/bvFetch/README.md
@@ -10,6 +10,8 @@ The BvFetch module provides methods to cache duplicate API calls and interact wi
 
 `cacheName (String):` Optional. Specifies the name of the cache to be used. If not provided, the default cache name 'bvCache' will be used.
 
+`cacheLimit (Integer)`: Optional. Specifies the cache size limit for the cache storage. Its value should be in MB. Default value is 10 MB.
+
 ## bvFetchFunc Method Parameters
 `url (String):` The URL of the API endpoint to fetch data from.
 
@@ -26,7 +28,7 @@ The BvFetch module provides methods to cache duplicate API calls and interact wi
 `string:` The generated cache key.
 
 ## updateCacheSize Method Parameters:
-`sizeChange (number):` The change in cache size.
+`responseSize (number):` The change in cache size.
 
 ## updateCacheSize Return Value: 
 This function does not return anything.
@@ -36,6 +38,12 @@ This function does not accept any parameters.
 
 ## retrieveCacheSize Return Value:
 Promise<number>: A promise that resolves to the retrieved cache size.
+
+## cleanupExpiredCache Method Parameters: 
+This function does not accept any parameters.
+
+## cleanupExpiredCache Return Value:
+This function does not return anything.
 
 ## flushCache Method Parameters
 This method takes no parameters.

--- a/lib/bvFetch/README.md
+++ b/lib/bvFetch/README.md
@@ -7,14 +7,11 @@ The BvFetch module provides methods to cache duplicate API calls and interact wi
 
 ## BvFetch Parameters
 `shouldCache (Function):` A function that takes the API response JSON as input and returns a boolean indicating whether to cache the response or not. This allows you to implement custom logic based on the response content. If caching is desired, the function should return true; otherwise, false.
-
 `cacheName (String):` Optional. Specifies the name of the cache to be used. If not provided, the default cache name 'bvCache' will be used.
-
 `cacheLimit (Integer)`: Optional. Specifies the cache size limit for the cache storage. Its value should be in MB. Default value is 10 MB.
 
 ## bvFetchFunc Method Parameters
 `url (String):` The URL of the API endpoint to fetch data from.
-
 `options (Object):` Optional request options such as headers, method, etc., as supported by the Fetch API.
 
 ## bvFetchFunc Return Value
@@ -23,33 +20,54 @@ The BvFetch module provides methods to cache duplicate API calls and interact wi
 ## generateCacheKey Method Parameters:
 `url (String):` The URL of the API endpoint.
 `options (Object):` Optional request options.
-
 ## generateCacheKey Return Value:
 `string:` The generated cache key.
 
-## updateCacheSize Method Parameters:
-`responseSize (number):` The change in cache size.
+## retrieveCachedUrls Method
+Retrieves cached URLs from the cache storage associated with the provided cache name.
+## retrieveCachedUrls Parameters
+This method takes no parameters.
+## retrieveCachedUrls Return Value
+`void:` This method does not return anything.
 
-## updateCacheSize Return Value: 
-This function does not return anything.
+## fetchDataAndCache Method
+Fetches data from the specified URL, caches the response, and returns the response.
+## Parameters
+`url (String):` The URL from which to fetch data.
+`options (Object):` Optional request options such as headers, method, etc., as supported by the 
+Fetch API.
+`cacheKey (String):`
+ The cache key associated with the fetched data.
+## Return Value
+`Promise<Response>:` A promise that resolves to the fetched response.
 
-## retrieveCacheSize Method Parameters: 
-This function does not accept any parameters.
+## fetchFromCache Method
+Function to fetch data from cache.
+## Parameters
+`cacheKey (String):` The cache key to fetch data from the cache.
+## Return Value
+Promise<Response|null>: A Promise that resolves with a Response object if the data is found in cache, or null if the data is not cached or expired.
 
-## retrieveCacheSize Return Value:
-Promise<number>: A promise that resolves to the retrieved cache size.
+## cacheData Method
+Caches the provided response with the specified cache key if it meets the criteria for caching.
+## Parameters
+`response (Response):` The response object to be cached.
+`cacheKey (String):` The cache key associated with the response.
+## Return Value
+`void:` This method does not return anything.
 
-## cleanupExpiredCache Method Parameters: 
-This function does not accept any parameters.
-
-## cleanupExpiredCache Return Value:
-This function does not return anything.
 
 ## flushCache Method Parameters
 This method takes no parameters.
-
 ## flushCache Return Value
 `Promise<void>:` A promise indicating the completion of cache flush operation.
+
+## manageCache Method
+Manages the cache by deleting expired cache entries and maintaining the cache size limit.
+## Parameters
+This method takes no parameters.
+## Return Value
+`void:` This method does not return anything.
 
 
 ## Usage with of `BvFetch`:

--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -10,6 +10,44 @@ module.exports = function BvFetch ({ shouldCache, cacheName }) {
   this.shouldCache = shouldCache;
   this.cacheName = cacheName || 'bvCache';
   this.fetchPromises = new Map();
+  this.cacheSize = 0;
+
+/**
+ * Updates the cache size based on the provided size change.
+ * @param {number} sizeChange - The change in cache size.
+ */
+  this.updateCacheSize = function (sizeChange) {
+    // Update cache size
+    const newCacheSize = this.cacheSize + sizeChange;
+    this.cacheSize = newCacheSize > 0 ? newCacheSize : 0
+    // Store the updated cache size in the cache
+    caches.open(this.cacheName).then(cache => {
+      cache.put('cacheSize', new Response(this.cacheSize.toString()));
+    }).catch(err => {
+      console.error('Error updating cache size:', err);
+    });
+  };
+
+/**
+ * Retrieves the cache size from the cache.
+ * @returns {Promise<number>} A promise that resolves to the retrieved cache size.
+ */
+  this.retrieveCacheSize = function () {
+    return caches.open(this.cacheName).then(cache => {
+      return cache.match('cacheSize').then(response => {
+        if (response) {
+          return response.text().then(size => parseInt(size, 10));
+        } 
+        else {
+          return 0; // Default value if cacheSize entry doesn't exist
+        }
+      });
+    }).catch(err => {
+      console.error('Error retrieving cache size:', err);
+      return 0; // Default value in case of error
+    });
+  };
+
 
   /**
    * Generates a unique cache key for the given URL and options.
@@ -25,6 +63,40 @@ module.exports = function BvFetch ({ shouldCache, cacheName }) {
   };
 
   /**
+ * Cleans up expired cache entries.
+ * This function iterates through all cached responses in the cache storage,
+ * checks each response's age against its TTL (time-to-live), and deletes
+ * any expired entries.
+ */
+
+  this.cleanupExpiredCache = function () {
+    caches.open(cacheName).then((cache) => {
+      cache.keys().then((keys) => {
+        var currentTime = Date.now();
+
+        keys.forEach((key) => {
+          // Skip processing cacheSize entry
+          if (key.url.includes('cacheSize')) {
+            return;
+          }
+          cache.match(key).then((cachedResponse) => {
+            if (cachedResponse) {
+              const cacheResponseSize = parseInt(cachedResponse.headers.get('X-Bazaarvoice-Cached-Size'), 10);
+              var cachedTime = parseInt(cachedResponse.headers.get('X-Bazaarvoice-Cached-Time'), 10);
+              var ttl = parseInt(cachedResponse.headers.get('Cache-Control').match(/max-age=(\d+)/)[1], 10);
+              var cacheAge = (currentTime - cachedTime) / 1000;
+              if (cacheAge >= ttl) {
+                this.updateCacheSize(-cacheResponseSize)
+                cache.delete(key);
+              }
+            }
+          });
+        });
+      });
+    });
+  };
+
+  /**
    * Fetches data from the API endpoint, caches responses, and handles caching logic.
    * @param {string} url - The URL of the API endpoint.
    * @param {Object} options - Optional request options.
@@ -35,18 +107,22 @@ module.exports = function BvFetch ({ shouldCache, cacheName }) {
     // get the key
     const cacheKey = this.generateCacheKey(url, options);
 
-    // check if its available in the cache
-    return caches.open(this.cacheName)
+    return this.retrieveCacheSize().then((cacheSize) => {
+      this.cacheSize = cacheSize;
+
+      // check if its available in the cache
+      return caches.open(this.cacheName)
       .then(currentCache => currentCache.match(cacheKey))
       .then(cachedResponse => {
         if (cachedResponse) {
-          const cachedTime = cachedResponse.headers.get('X-Cached-Time');
+          const cachedTime = cachedResponse.headers.get('X-Bazaarvoice-Cached-Time');
           const ttl = cachedResponse.headers.get('Cache-Control').match(/max-age=(\d+)/)[1];
           const currentTimestamp = Date.now();
           const cacheAge = (currentTimestamp - cachedTime) / 1000;
 
           if (cacheAge < ttl) {
             // Cached response found
+            this.cleanupExpiredCache()
             return cachedResponse.clone();
           }
         }
@@ -65,45 +141,69 @@ module.exports = function BvFetch ({ shouldCache, cacheName }) {
         return newPromise
           .then(response => {
             const clonedResponse = response.clone();
-            const errJson = clonedResponse.clone()
-            let canBeCached = true;
-            return errJson.json().then(json => {
-              if (typeof this.shouldCache === 'function') {
-                canBeCached = this.shouldCache(json);
-              }
-              return response
-            }).then(res => {
-              if (canBeCached) {
-                const newHeaders = new Headers();
-                clonedResponse.headers.forEach((value, key) => {
-                  newHeaders.append(key, value);
-                });
-                newHeaders.append('X-Cached-Time', Date.now());
+            const checkResSize = response.clone();
 
-                const newResponse = new Response(clonedResponse._bodyBlob, {
-                  status: clonedResponse.status,
-                  statusText: clonedResponse.statusText,
-                  headers: newHeaders
-                });
-                //Delete promise from promise map once its resolved
+            // Read the response body as text
+            return checkResSize.text().then(text => {
+              // Calculate the byte length of the response text
+              const size = new Blob([text]).size;
+
+
+              // Check if the cumulative response size exceeds 10MB
+              if (this.cacheSize > 10 * 1024 * 1024) {
+                //Delete promise from promise map if size exceeds limit
                 this.fetchPromises.delete(cacheKey);
-
-                return caches.open(this.cacheName)
-                .then(currentCache =>
-                  currentCache.put(cacheKey, newResponse)
-                )
-                .then(() => res);
-              } 
-              else {
-                //Delete promise from promise map if error exists
-                this.fetchPromises.delete(cacheKey);
-
-                return res
+                return response;
               }
 
+              // Check if the response should be cached based on custom logic
+              let canBeCached = true;
+              const errJson = clonedResponse.clone();
+              return errJson.json().then(json => {
+                if (typeof this.shouldCache === 'function') {
+                  canBeCached = this.shouldCache(json);
+                }
+                return response
+              }).then(res => { 
+                if (canBeCached) {
+                  const newHeaders = new Headers();
+                  clonedResponse.headers.forEach((value, key) => {
+                    newHeaders.append(key, value);
+                  });
+                  newHeaders.append('X-Bazaarvoice-Cached-Time', Date.now());
+                  newHeaders.append('X-Bazaarvoice-Cached-Size', size);
+                  const newResponse = new Response(clonedResponse._bodyBlob || clonedResponse.body, {
+                    status: clonedResponse.status,
+                    statusText: clonedResponse.statusText,
+                    headers: newHeaders
+                  });
+
+                  // Clean up the old cached responses before caching new response
+                  this.cleanupExpiredCache()
+
+                  //Delete promise from promise map once its resolved
+                  this.fetchPromises.delete(cacheKey);
+                  
+                  // Update cumulative response size
+                  this.updateCacheSize(size)
+                  
+                  return caches.open(this.cacheName)
+                    .then(currentCache =>
+                      currentCache.put(cacheKey, newResponse)
+                    )
+                    .then(() => res);
+                } 
+                else {
+                  //Delete promise from promise map if error exists
+                  this.fetchPromises.delete(cacheKey);
+                  return res;
+                }
+              })
             });
-          })
+          });
       })
+
+    })
       .catch(err => {
         // Remove the promise that was pushed earlier
         this.fetchPromises.delete(cacheKey);

--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -9,7 +9,7 @@ const { fetch } = require('../polyfills/fetch')
 module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
   this.shouldCache = shouldCache;
   this.cacheName = cacheName || 'bvCache';
-  this.cacheLimit = cacheLimit * 1024 * 1024 || 10 * 1024 * 1024
+  this.cacheLimit = cacheLimit * 1024 * 1024 || 10 * 1024 * 1024;
   this.fetchPromises = new Map();
   this.cachedUrls = new Set();
 
@@ -45,7 +45,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
   }
 
   //callretrieveCachedUrls function to set the cache URL set with the cached URLS
-  this.retrieveCachedUrls()
+  this.retrieveCachedUrls();
 
   /**
     * Fetches data from the specified URL, caches the response, and returns the response.
@@ -58,7 +58,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
     return fetch(url,options)
       .then((response) => {
         // initiate caching of response and return the response
-        this.cacheData(response, cacheKey)
+        this.cacheData(response, cacheKey);
         return response.clone();
       })
       .catch(function (error) {
@@ -74,7 +74,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
   */
 
   this.cacheData = (response, cacheKey) => {
-    const errJson = response.clone()
+    const errJson = response.clone();
     let canBeCached = true;
     // Check for error in response obj
     errJson.json().then(json => {
@@ -157,14 +157,14 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
 
   this.bvFetchFunc = (url, options = {}) => {
 
-    const cacheKey = this.generateCacheKey(url, options)
+    const cacheKey = this.generateCacheKey(url, options);
   // If an ongoing fetch promise exists for the URL, return it
     if (this.fetchPromises.has(cacheKey)) {
       return this.fetchPromises.get(cacheKey).then(res => res.clone());
     }
 
   // Check if response is available in cache
-    var newPromise = this.fetchFromCache(cacheKey)
+    const newPromise = this.fetchFromCache(cacheKey)
       .then((cachedResponse) => {
           // If response found in cache, return it
         if (cachedResponse) {
@@ -178,7 +178,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
     this.fetchPromises.set(cacheKey, newPromise);
 
     //initiate cache cleanUp
-    this.debounceCleanupExpiredCache()
+    this.debounceCleanupExpiredCache();
 
     // When fetch completes or fails, remove the promise from the store
     newPromise.finally(() => {

--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -6,19 +6,20 @@
 
 const { fetch } = require('../polyfills/fetch')
 
-module.exports = function BvFetch ({ shouldCache, cacheName }) {
+module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit=10 }) {
   this.shouldCache = shouldCache;
   this.cacheName = cacheName || 'bvCache';
+  this.cacheLimit = cacheLimit * 1024 * 1024;
   this.fetchPromises = new Map();
   this.cacheSize = 0;
 
 /**
  * Updates the cache size based on the provided size change.
- * @param {number} sizeChange - The change in cache size.
+ * @param {number} responseSize - The response size in bits.
  */
-  this.updateCacheSize = function (sizeChange) {
+  this.updateCacheSize = function (responseSize) {
     // Update cache size
-    const newCacheSize = this.cacheSize + sizeChange;
+    const newCacheSize = this.cacheSize + responseSize;
     this.cacheSize = newCacheSize > 0 ? newCacheSize : 0
     // Store the updated cache size in the cache
     caches.open(this.cacheName).then(cache => {
@@ -70,7 +71,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName }) {
  */
 
   this.cleanupExpiredCache = function () {
-    caches.open(cacheName).then((cache) => {
+    return caches.open(cacheName).then((cache) => {
       cache.keys().then((keys) => {
         var currentTime = Date.now();
 
@@ -150,7 +151,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName }) {
 
 
               // Check if the cumulative response size exceeds 10MB
-              if (this.cacheSize > 10 * 1024 * 1024) {
+              if (this.cacheSize > this.cacheLimit) {
                 //Delete promise from promise map if size exceeds limit
                 this.fetchPromises.delete(cacheKey);
                 return response;
@@ -178,14 +179,16 @@ module.exports = function BvFetch ({ shouldCache, cacheName }) {
                     headers: newHeaders
                   });
 
-                  // Clean up the old cached responses before caching new response
-                  this.cleanupExpiredCache()
 
                   //Delete promise from promise map once its resolved
                   this.fetchPromises.delete(cacheKey);
+
+                  // Clean up the old cached responses before caching new response
+                  this.cleanupExpiredCache().then(() => {
+                    // Update cumulative response size
+                    this.updateCacheSize(size);
+                  })
                   
-                  // Update cumulative response size
-                  this.updateCacheSize(size)
                   
                   return caches.open(this.cacheName)
                     .then(currentCache =>

--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -6,49 +6,12 @@
 
 const { fetch } = require('../polyfills/fetch')
 
-module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit=10 }) {
+module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
   this.shouldCache = shouldCache;
   this.cacheName = cacheName || 'bvCache';
-  this.cacheLimit = cacheLimit * 1024 * 1024;
+  this.cacheLimit = cacheLimit * 1024 * 1024 || 10 * 1024 * 1024
   this.fetchPromises = new Map();
-  this.cacheSize = 0;
-
-/**
- * Updates the cache size based on the provided size change.
- * @param {number} responseSize - The response size in bits.
- */
-  this.updateCacheSize = function (responseSize) {
-    // Update cache size
-    const newCacheSize = this.cacheSize + responseSize;
-    this.cacheSize = newCacheSize > 0 ? newCacheSize : 0
-    // Store the updated cache size in the cache
-    caches.open(this.cacheName).then(cache => {
-      cache.put('cacheSize', new Response(this.cacheSize.toString()));
-    }).catch(err => {
-      console.error('Error updating cache size:', err);
-    });
-  };
-
-/**
- * Retrieves the cache size from the cache.
- * @returns {Promise<number>} A promise that resolves to the retrieved cache size.
- */
-  this.retrieveCacheSize = function () {
-    return caches.open(this.cacheName).then(cache => {
-      return cache.match('cacheSize').then(response => {
-        if (response) {
-          return response.text().then(size => parseInt(size, 10));
-        } 
-        else {
-          return 0; // Default value if cacheSize entry doesn't exist
-        }
-      });
-    }).catch(err => {
-      console.error('Error retrieving cache size:', err);
-      return 0; // Default value in case of error
-    });
-  };
-
+  this.cachedUrls = new Set();
 
   /**
    * Generates a unique cache key for the given URL and options.
@@ -64,38 +27,126 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit=10 }) {
   };
 
   /**
- * Cleans up expired cache entries.
- * This function iterates through all cached responses in the cache storage,
- * checks each response's age against its TTL (time-to-live), and deletes
- * any expired entries.
- */
+  * Retrieves cached URLs from the cache storage associated with the provided cache name.
+  * @returns {void}
+  */
 
-  this.cleanupExpiredCache = function () {
-    return caches.open(cacheName).then((cache) => {
-      cache.keys().then((keys) => {
-        var currentTime = Date.now();
-
-        keys.forEach((key) => {
-          // Skip processing cacheSize entry
-          if (key.url.includes('cacheSize')) {
-            return;
-          }
-          cache.match(key).then((cachedResponse) => {
-            if (cachedResponse) {
-              const cacheResponseSize = parseInt(cachedResponse.headers.get('X-Bazaarvoice-Cached-Size'), 10);
-              var cachedTime = parseInt(cachedResponse.headers.get('X-Bazaarvoice-Cached-Time'), 10);
-              var ttl = parseInt(cachedResponse.headers.get('Cache-Control').match(/max-age=(\d+)/)[1], 10);
-              var cacheAge = (currentTime - cachedTime) / 1000;
-              if (cacheAge >= ttl) {
-                this.updateCacheSize(-cacheResponseSize)
-                cache.delete(key);
-              }
-            }
-          });
+  this.retrieveCachedUrls = () => {
+    // Open the Cache Storage
+    caches.open(this.cacheName).then(cache => {
+    // Get all cache keys
+      cache.keys().then(keys => {
+        keys.forEach(request => {
+          this.cachedUrls.add(request.url);
         });
       });
     });
-  };
+
+  }
+
+  //callretrieveCachedUrls function to set the cache URL set with the cached URLS
+  this.retrieveCachedUrls()
+
+  /**
+    * Fetches data from the specified URL, caches the response, and returns the response.
+    * @param {string} url - The URL from which to fetch data.
+    * @param {string} cacheKey - The cache key associated with the fetched data.
+    * @returns {Promise<Response>} A Promise that resolves with the fetched response.
+    * @throws {Error} Throws an error if there's any problem fetching the data.
+  */
+  this.fetchDataAndCache = (url, options = {}, cacheKey) => {
+    return fetch(url,options)
+      .then((response) => {
+        // initiate caching of response and return the response
+        this.cacheData(response, cacheKey)
+        return response.clone();
+      })
+      .catch(function (error) {
+        throw new Error('Error fetching data: ' + error);
+      });
+  }
+
+  /**
+    * Caches the provided response with the specified cache key if it meets the criteria for caching.
+    * @param {Response} response - The response object to be cached.
+    * @param {string} cacheKey - The cache key associated with the response.
+    * @returns {void}
+  */
+
+  this.cacheData = (response, cacheKey) => {
+    const errJson = response.clone()
+    let canBeCached = true;
+    // Check for error in response obj
+    errJson.json().then(json => {
+      if (typeof this.shouldCache === 'function') {
+        canBeCached = this.shouldCache(json);
+      }
+    }).then(() => {
+      if (canBeCached) {
+        const clonedResponse = response.clone()
+        const newHeaders = new Headers();
+        clonedResponse.headers.forEach((value, key) => {
+          newHeaders.append(key, value);
+        });
+        newHeaders.append('X-Bazaarvoice-Cached-Time', Date.now())
+        // Get response text to calculate its size
+        clonedResponse.text().then(text => {
+        // Calculate size of response text in bytes
+          const sizeInBytes = new Blob([text]).size;
+
+        // Append response size to headers
+          newHeaders.append('X-Bazaarvoice-Response-Size', sizeInBytes);
+
+        // Create new Response object with modified headers
+          const newResponse = new Response(clonedResponse._bodyBlob || clonedResponse.body, {
+            status: clonedResponse.status,
+            statusText: clonedResponse.statusText,
+            headers: newHeaders
+          });
+          // Cache the response
+          caches.open(this.cacheName).then(cache => {
+            cache.put(cacheKey, newResponse);
+            //add key to cachedUrls set
+            this.cachedUrls.add(cacheKey);
+          });
+        });
+      }
+    })
+  }
+
+  /**
+    * Function to fetch data from cache.
+    * @param {string} cacheKey - The cache key to fetch data from the cache.
+    * @returns {Promise<Response|null>} A Promise that resolves with a Response object if the data is found in cache, 
+    * or null if the data is not cached or expired.
+    * @throws {Error} Throws an error if there's any problem fetching from cache.
+  */
+  this.fetchFromCache = (cacheKey) => {
+    // Check if the URL is in the set of cached URLs
+    if (!this.cachedUrls.has(cacheKey)) {
+      return Promise.resolve(null);
+    }
+
+    // Open the cache and try to match the URL
+    return caches.open(this.cacheName)
+      .then((cache) => {
+        return cache.match(cacheKey)
+          .then((cachedResponse) => {
+                  
+            const cachedTime = cachedResponse.headers.get('X-Bazaarvoice-Cached-Time');
+            const ttl = cachedResponse.headers.get('Cache-Control').match(/max-age=(\d+)/)[1];
+            const currentTimestamp = Date.now();
+            const cacheAge = (currentTimestamp - cachedTime) / 1000;
+            if (cacheAge < ttl) {
+              // Cached response found
+              return cachedResponse.clone();
+            }
+          })
+      })
+      .catch((error) => {
+        throw new Error('Error fetching from cache: ' + error);
+      });
+  }
 
   /**
    * Fetches data from the API endpoint, caches responses, and handles caching logic.
@@ -105,114 +156,38 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit=10 }) {
    */
 
   this.bvFetchFunc = (url, options = {}) => {
-    // get the key
-    const cacheKey = this.generateCacheKey(url, options);
 
-    return this.retrieveCacheSize().then((cacheSize) => {
-      this.cacheSize = cacheSize;
+    const cacheKey = this.generateCacheKey(url, options)
+  // If an ongoing fetch promise exists for the URL, return it
+    if (this.fetchPromises.has(cacheKey)) {
+      return this.fetchPromises.get(cacheKey).then(res => res.clone());
+    }
 
-      // check if its available in the cache
-      return caches.open(this.cacheName)
-      .then(currentCache => currentCache.match(cacheKey))
-      .then(cachedResponse => {
+  // Check if response is available in cache
+    var newPromise = this.fetchFromCache(cacheKey)
+      .then((cachedResponse) => {
+          // If response found in cache, return it
         if (cachedResponse) {
-          const cachedTime = cachedResponse.headers.get('X-Bazaarvoice-Cached-Time');
-          const ttl = cachedResponse.headers.get('Cache-Control').match(/max-age=(\d+)/)[1];
-          const currentTimestamp = Date.now();
-          const cacheAge = (currentTimestamp - cachedTime) / 1000;
-
-          if (cacheAge < ttl) {
-            // Cached response found
-            this.cleanupExpiredCache()
-            return cachedResponse.clone();
-          }
+          return cachedResponse;
         }
-
-        // check if there is an ongoing promise
-        if (this.fetchPromises.has(cacheKey)) {
-          return this.fetchPromises.get(cacheKey).then(res => res.clone());
-        }
-
-        // Make a new call
-        const newPromise = fetch(url, options);
-
-        // Push the newPromise to the fetchPromises Map
-        this.fetchPromises.set(cacheKey, newPromise);
-
-        return newPromise
-          .then(response => {
-            const clonedResponse = response.clone();
-            const checkResSize = response.clone();
-
-            // Read the response body as text
-            return checkResSize.text().then(text => {
-              // Calculate the byte length of the response text
-              const size = new Blob([text]).size;
-
-
-              // Check if the cumulative response size exceeds 10MB
-              if (this.cacheSize > this.cacheLimit) {
-                //Delete promise from promise map if size exceeds limit
-                this.fetchPromises.delete(cacheKey);
-                return response;
-              }
-
-              // Check if the response should be cached based on custom logic
-              let canBeCached = true;
-              const errJson = clonedResponse.clone();
-              return errJson.json().then(json => {
-                if (typeof this.shouldCache === 'function') {
-                  canBeCached = this.shouldCache(json);
-                }
-                return response
-              }).then(res => { 
-                if (canBeCached) {
-                  const newHeaders = new Headers();
-                  clonedResponse.headers.forEach((value, key) => {
-                    newHeaders.append(key, value);
-                  });
-                  newHeaders.append('X-Bazaarvoice-Cached-Time', Date.now());
-                  newHeaders.append('X-Bazaarvoice-Cached-Size', size);
-                  const newResponse = new Response(clonedResponse._bodyBlob || clonedResponse.body, {
-                    status: clonedResponse.status,
-                    statusText: clonedResponse.statusText,
-                    headers: newHeaders
-                  });
-
-
-                  //Delete promise from promise map once its resolved
-                  this.fetchPromises.delete(cacheKey);
-
-                  // Clean up the old cached responses before caching new response
-                  this.cleanupExpiredCache().then(() => {
-                    // Update cumulative response size
-                    this.updateCacheSize(size);
-                  })
-                  
-                  
-                  return caches.open(this.cacheName)
-                    .then(currentCache =>
-                      currentCache.put(cacheKey, newResponse)
-                    )
-                    .then(() => res);
-                } 
-                else {
-                  //Delete promise from promise map if error exists
-                  this.fetchPromises.delete(cacheKey);
-                  return res;
-                }
-              })
-            });
-          });
-      })
-
-    })
-      .catch(err => {
-        // Remove the promise that was pushed earlier
-        this.fetchPromises.delete(cacheKey);
-        throw err;
+          // If response not found in cache, fetch from API and cache it
+        return this.fetchDataAndCache(url, options, cacheKey);
       });
-  };
+
+    // Store the ongoing fetch promise
+    this.fetchPromises.set(cacheKey, newPromise);
+
+    //initiate cache cleanUp
+    this.debounceCleanupExpiredCache()
+
+    // When fetch completes or fails, remove the promise from the store
+    newPromise.finally(() => {
+      this.fetchPromises.delete(cacheKey);
+    });
+
+    return newPromise.then(res => res.clone());
+  }
+
 
   /**
    * Clears all cache entries stored in the cache storage.
@@ -227,5 +202,89 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit=10 }) {
       });
     });
   };
+
+  this.manageCache = () => {
+    // Delete expired cache entries
+    caches.open(this.cacheName).then(cache => {
+      cache.keys().then(keys => {
+        keys.forEach(key => {
+          cache.match(key).then(response => {
+            const cachedTime = response.headers.get('X-Bazaarvoice-Cached-Time');
+            const ttl = response.headers.get('Cache-Control').match(/max-age=(\d+)/)[1];
+            const currentTimestamp = Date.now();
+            const cacheAge = (currentTimestamp - cachedTime) / 1000;
+            if (cacheAge >= ttl) {
+              cache.delete(key);
+              this.cachedUrls.delete(key);
+            }
+          });
+        });
+      });
+    });
+
+    // Calculate total size of cached responses
+    let totalSize = 0;
+    caches.open(this.cacheName).then(cache => {
+      cache.keys().then(keys => {
+        // Create an array of promises for cache match operations
+        const matchPromises = keys.map(key =>
+                cache.match(key).then(response => {
+                  const sizeHeader = response.headers.get('X-Bazaarvoice-Response-Size');
+                  return parseInt(sizeHeader, 10);
+                })
+            );
+
+        // wait for all match promises to resolve
+        return Promise.all(matchPromises)
+          .then(sizes => sizes.reduce((acc, size) => acc + size, 0));
+      }).then(size => {
+        totalSize = size;
+        // If total size exceeds 10 MB, delete old cache entries
+        if (totalSize > this.cacheLimit) {
+
+          // create an array of cached responses
+          const cacheEntries = [];
+          return cache.keys().then(keys => {
+            const cachesResEntries = keys.map(key =>
+              cache.match(key).then(response => {
+                const sizeHeader = response.headers.get('X-Bazaarvoice-Response-Size');
+                const lastAccessedTime = response.headers.get('X-Bazaarvoice-Cached-Time');
+                cacheEntries.push({ key, size: parseInt(sizeHeader, 10), lastAccessedTime });
+              })
+            );
+
+            return Promise.all(cachesResEntries)
+            .then(() => {
+              // Sort cache entries by last accessed time in ascending order
+              cacheEntries.sort((a, b) => a.lastAccessedTime - b.lastAccessedTime);
+              
+              // Delete older cache entries until total size is under 10 MB
+              let currentSize = totalSize;
+              cacheEntries.forEach(entry => {
+                if (currentSize > this.cacheLimit) {
+                  cache.delete(entry.key);
+                  this.cachedUrls.delete(entry.key);
+                  currentSize -= entry.size;
+                }
+              });
+            });
+          });
+        }
+      });
+    });
+  };
+
+
+  function debounce (func, delay) {
+    let timer;
+    return function () {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        func.apply(this, arguments);
+      }, delay);
+    };
+  }
+
+  this.debounceCleanupExpiredCache = debounce(this.manageCache, 8000);
   
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {

--- a/test/unit/bvFetch/index.spec.js
+++ b/test/unit/bvFetch/index.spec.js
@@ -133,7 +133,7 @@ describe('BvFetch', function () {
     bvFetchInstance.shouldCache = (res) => {
       return false
     };
-  
+ 
     bvFetchInstance.bvFetchFunc(url, options)
     .then(response => {
       // Check if response is fetched from network
@@ -141,7 +141,7 @@ describe('BvFetch', function () {
       console.log(response.body)
 
       // Check if caches.match was called
-      expect(cacheStub.calledOnce).to.be.true;
+      expect(cacheStub.calledOnce).to.be.false;
 
       // Check if response is not cached
       const cachedResponse = cacheStorage.get(url);

--- a/test/unit/bvFetch/index.spec.js
+++ b/test/unit/bvFetch/index.spec.js
@@ -65,7 +65,7 @@ describe('BvFetch', function () {
     caches.open.resolves({
       match: (key) => {
         expect(key).to.equal(cacheKey); 
-        Promise.resolve(mockResponse)
+        return Promise.resolve(mockResponse)
       },
       put: (key, response) => {
         cacheStorage.set(key, response);
@@ -73,6 +73,10 @@ describe('BvFetch', function () {
       }
     });
   
+    // Simulate that the response is cached
+    bvFetchInstance.cachedUrls.add(cacheKey);
+    
+    // Call the function under test
     bvFetchInstance.bvFetchFunc(url, options)
     .then(response => {
       // Check if response is fetched from cache
@@ -91,19 +95,15 @@ describe('BvFetch', function () {
       done(error); // Call done with error if any
     })
   });
-  
 
+  
   it('should fetch from network when response is not cached', function (done) {
     const url = 'https://jsonplaceholder.typicode.com/todos';
     const options = {};
 
-    const cacheKey = bvFetchInstance.generateCacheKey(url, options);
-  
+    const matchSpy = sinon.spy();
     caches.open.resolves({
-      match: (key) => {
-        expect(key).to.equal(cacheKey); 
-        Promise.resolve(null)
-      },
+      match: matchSpy,
       put: (key, response) => {
         cacheStorage.set(key, response);
         return Promise.resolve();
@@ -118,7 +118,7 @@ describe('BvFetch', function () {
         console.log(response.body)
         
         // Check if caches.match was called
-        expect(cacheStub.called).to.be.true;
+        expect(matchSpy.called).to.be.false;
 
         done();
       })
@@ -150,7 +150,6 @@ describe('BvFetch', function () {
       done();
     })
     .catch(done);
-  });
-
+  }); 
   
 });


### PR DESCRIPTION

<!-- Replace XXX with the number of the JIRA ticket. -->
[PD-237465](https://bazaarvoice.atlassian.net/browse/PD-237465)
[PD-237445](https://bazaarvoice.atlassian.net/browse/PD-237445)

## Problem/Goal

Fixing bugs in bvFetch module. in firefox when adBlocker extenstion is enabled the cached response is null.

## Solution

Added a condition to get body from response.body when window fetch is used. Added cache expiry mechanism and added cache limit of 10 MB


[PD-237465]: https://bazaarvoice.atlassian.net/browse/PD-237465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PD-237445]: https://bazaarvoice.atlassian.net/browse/PD-237445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ