### PR TITLE
Bv fetch changes to fix, PD-238557

### DIFF
--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -83,14 +83,15 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
       }
     }).then(() => {
       if (canBeCached) {
-        const clonedResponse = response.clone()
+        const clonedResponse = response.clone();
+        const sizeCheck = response.clone();
         const newHeaders = new Headers();
         clonedResponse.headers.forEach((value, key) => {
           newHeaders.append(key, value);
         });
         newHeaders.append('X-Bazaarvoice-Cached-Time', Date.now())
         // Get response text to calculate its size
-        clonedResponse.text().then(text => {
+        sizeCheck.text().then(text => {
         // Calculate size of response text in bytes
           const sizeInBytes = new Blob([text]).size;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {

--- a/test/unit/bvFetch/index.spec.js
+++ b/test/unit/bvFetch/index.spec.js
@@ -140,16 +140,17 @@ describe('BvFetch', function () {
     bvFetchInstance.bvFetchFunc(url, options)
     .then(response => {
       // Check if response is fetched from network
-      expect(response).to.not.be.null;
-      console.log(response.body)
+      setTimeout(() => { 
+        expect(response).to.not.be.null;
+        console.log(response.body)
 
       // Check if caches.match was called
-      expect(cacheStub.calledOnce).to.be.false;
+        expect(cacheStub.calledOnce).to.be.false;
 
       // Check if response is not cached
-      const cachedResponse = cacheStorage.get(url);
-      expect(cachedResponse).to.be.undefined;
-
+        const cachedResponse = cacheStorage.get(url);
+        expect(cachedResponse).to.be.undefined; 
+      }, 500)
       done();
     })
     .catch(done);


### PR DESCRIPTION
# PR description
An error is being thrown in performance test page.

<!--Mention the JIRA ticket numbers below-->

## JIRA tickets

[PD-238557](https://bazaarvoice.atlassian.net/browse/PD-238557)

<!--Please mention if the PR is for a feature or bug. Select both if it contains both-->

## This PR is for

- Bug

<!--Mention the requirements / issues in points-->

## Requirements / issues

- Error is being thrown in performance test page. Because the response body is being used twice, once for checking size once for caching response body.

<!--Mention the steps taken to solve each of the above points-->

## Solutions

- Point 1
  - Creating separate clone of the response to check for size and caching.

## Steps to verify

- As Part of the verification, deploy version with bvFetch and check that there are no console errors in the test page on pageLoad.

## Check points

<!-- Design/approach documented in confluence and in the story -->

- [x] Design / approach doc
<!-- Should have the functionality as in the story -->
- [x] Functionality


[PD-235835]: https://bazaarvoice.atlassian.net/browse/PD-235835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PD-238557]: https://bazaarvoice.atlassian.net/browse/PD-238557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ