### PR TITLE
Csat pd 254370 bv fetch cache issue

### DIFF
--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -167,6 +167,10 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
   // Check if response is available in cache
     const newPromise = this.fetchFromCache(cacheKey)
       .then((cachedResponse) => {
+        if (!cachedResponse) {
+          this.cachedUrls.delete(cacheKey)
+          return Promise.resolve(null);
+        }  
           // If response found in cache, return it
         if (cachedResponse) {
           return cachedResponse;

--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -1,4 +1,3 @@
-
 /**
  * @fileOverview
  * Provides api response caching utilties
@@ -133,7 +132,10 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
       .then((cache) => {
         return cache.match(cacheKey)
           .then((cachedResponse) => {
-                  
+            if (!cachedResponse) {
+              this.cachedUrls.delete(cacheKey)
+              return Promise.resolve(null);
+            }         
             const cachedTime = cachedResponse.headers.get('X-Bazaarvoice-Cached-Time');
             const ttl = cachedResponse.headers.get('Cache-Control').match(/max-age=(\d+)/)[1];
             const currentTimestamp = Date.now();
@@ -167,10 +169,6 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
   // Check if response is available in cache
     const newPromise = this.fetchFromCache(cacheKey)
       .then((cachedResponse) => {
-        if (!cachedResponse) {
-          this.cachedUrls.delete(cacheKey)
-          return Promise.resolve(null);
-        }  
           // If response found in cache, return it
         if (cachedResponse) {
           return cachedResponse;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {


### PR DESCRIPTION
# PR description

<!--Mention the JIRA ticket numbers below-->

## JIRA tickets

[PD-254370](https://bazaarvoice.atlassian.net/browse/PD-254370)

<!--Please mention if the PR is for a feature or bug. Select both if it contains both-->

## This PR is for

- Bug

<!--Mention the requirements / issues in points-->

## Requirements / issues

- Some clients have a feature that clears the cache on every reload. This action removes the bvFetch cache, and on the next reload, when the webpage tries to access the cache, the reviews container fails due to the cache no longer being available.

<!--Mention the steps taken to solve each of the above points-->

## Solutions

- The solution is to ensure that when the page attempts to access the cache and finds it does not exist, it is recommended to trigger the fetch call again to the API.


[PD-254370]: https://bazaarvoice.atlassian.net/browse/PD-254370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ