### PR TITLE
Csat pd 254370 bv fetch issue (#144)

### DIFF
--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -1,4 +1,3 @@
-
 /**
  * @fileOverview
  * Provides api response caching utilties
@@ -133,7 +132,10 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
       .then((cache) => {
         return cache.match(cacheKey)
           .then((cachedResponse) => {
-                  
+            if (!cachedResponse) {
+              this.cachedUrls.delete(cacheKey)
+              return Promise.resolve(null);
+            }         
             const cachedTime = cachedResponse.headers.get('X-Bazaarvoice-Cached-Time');
             const ttl = cachedResponse.headers.get('Cache-Control').match(/max-age=(\d+)/)[1];
             const currentTimestamp = Date.now();
@@ -167,10 +169,6 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
   // Check if response is available in cache
     const newPromise = this.fetchFromCache(cacheKey)
       .then((cachedResponse) => {
-        if (!cachedResponse) {
-          this.cachedUrls.delete(cacheKey)
-          return Promise.resolve(null);
-        }  
           // If response found in cache, return it
         if (cachedResponse) {
           return cachedResponse;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.4",
+  "version": "2.9.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.4",
+  "version": "2.9.6",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {


### PR DESCRIPTION
* [PD-254370]: Bv fetch issue resolved

* Release 2.9.5

* Release 2.9.6

Fixed BVFetch deleted cache key issue.
Manually removing the cache key if the cache for that key is not available.

[PD-254370]: https://bazaarvoice.atlassian.net/browse/PD-254370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ