### PR TITLE
allowing bvFetch to honor change the request headers while caching

### DIFF
--- a/lib/bvFetch/README.md
+++ b/lib/bvFetch/README.md
@@ -21,13 +21,13 @@ The BvFetch module provides methods to cache duplicate API calls and interact wi
 `url (String):` The URL of the API endpoint.
 `options (Object):` Optional request options.
 ## generateCacheKey Return Value:
-`string:` The generated cache key.
+`Request:` The generated cache key.
 
-## retrieveCachedUrls Method
-Retrieves cached URLs from the cache storage associated with the provided cache name.
-## retrieveCachedUrls Parameters
+## retrievecachedRequests Method
+Retrieves cached Requests from the cache storage associated with the provided cache name.
+## retrievecachedRequests Parameters
 This method takes no parameters.
-## retrieveCachedUrls Return Value
+## retrievecachedRequests Return Value
 `void:` This method does not return anything.
 
 ## fetchDataAndCache Method

--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -10,41 +10,79 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
   this.cacheName = cacheName || 'bvCache';
   this.cacheLimit = cacheLimit * 1024 * 1024 || 10 * 1024 * 1024;
   this.fetchPromises = new Map();
-  this.cachedUrls = new Set();
+  this.cachedRequests = new Set();
 
   /**
-   * Generates a unique cache key for the given URL and options.
-   * @param {string} url - The URL of the API endpoint.
-   * @param {Object} options - Optional request options.
-   * @returns {string} The generated cache key.
+   * Checks if a request is present in a set of cached URLs.
+   *
+   * @param {Set} cachedRequests - A set of cached request objects.
+   * @param {Object} cacheKey - The request object to check for in the cachedRequests set.
+   * @param {string} cacheKey.url - The URL of the request.
+   * @param {Headers} cacheKey.headers - The headers of the request.
+   * @returns {boolean} - Returns true if the request is found in the cachedRequests set, otherwise false.
    */
+  function isRequestInSet (cachedRequests, cacheKey) {
+    // Convert the Set to an array and check if any request matches
+    return [...cachedRequests].some((cachedRequest) => {
+      // Compare URLs
+      if (cachedRequest.url !== cacheKey.url) {
+        return false;
+      }
+  
+      // Compare headers
+      const cachedHeaders = [...cachedRequest.headers.entries()];
+      const keyHeaders = [...cacheKey.headers.entries()];
+  
+      if (cachedHeaders.length !== keyHeaders.length) {
+        return false; // Different number of headers
+      }
+  
+      return cachedHeaders.every(([key, value]) => {
+        return cacheKey.headers.get(key) === value;
+      });
+    });
+  }
+  
+
+  /**
+     * Creates a new Request object with the given URL and options.
+     *
+     * @param {string} url - The URL to which the request is sent.
+     * @param {Object} options - The options to apply to the request.
+     * @returns {Request} The created Request object.
+     */
 
   this.generateCacheKey =  (url, options) => {
-    const optionsString = (Object.keys(options).length > 0) ? JSON.stringify(options) : '';
-    const key = url + optionsString;
+    const key = new Request(url, options);
     return key;
   };
 
   /**
-  * Retrieves cached URLs from the cache storage associated with the provided cache name.
+  * Retrieves cached Requests from the cache storage associated with the provided cache name.
   * @returns {void}
   */
 
-  this.retrieveCachedUrls = () => {
+  this.retrievecachedRequests = () => {
     // Open the Cache Storage
     caches.open(this.cacheName).then(cache => {
     // Get all cache keys
       cache.keys().then(keys => {
         keys.forEach(request => {
-          this.cachedUrls.add(request.url);
+          const headers = {};
+          request.headers.forEach((value, key) => {
+            headers[key] = value;
+          });
+
+          // Generate the cache key with headers and URL
+          const cacheKey = this.generateCacheKey(request.url, { headers });
+          this.cachedRequests.add(cacheKey); // Add to the set
         });
       });
     });
-
   }
 
-  //callretrieveCachedUrls function to set the cache URL set with the cached URLS
-  this.retrieveCachedUrls();
+  //callretrievecachedRequests function to set the cache URL set with the cached URLS
+  this.retrievecachedRequests();
 
   /**
     * Fetches data from the specified URL, caches the response, and returns the response.
@@ -78,7 +116,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
     // Check for error in response obj
     errJson.json().then(json => {
       if (typeof this.shouldCache === 'function') {
-        canBeCached = this.shouldCache(json);
+        canBeCached = this.shouldCache(json.response ? json.response : json);
       }
     }).then(() => {
       if (canBeCached) {
@@ -106,8 +144,8 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
           // Cache the response
           caches.open(this.cacheName).then(cache => {
             cache.put(cacheKey, newResponse);
-            //add key to cachedUrls set
-            this.cachedUrls.add(cacheKey);
+            //add key to cachedRequests set
+            this.cachedRequests.add(cacheKey);
           });
         });
       }
@@ -122,8 +160,8 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
     * @throws {Error} Throws an error if there's any problem fetching from cache.
   */
   this.fetchFromCache = (cacheKey) => {
-    // Check if the URL is in the set of cached URLs
-    if (!this.cachedUrls.has(cacheKey)) {
+    // Check if the URL is in the set of cached requests set
+    if (!isRequestInSet(this.cachedRequests, cacheKey)) {
       return Promise.resolve(null);
     }
 
@@ -133,7 +171,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
         return cache.match(cacheKey)
           .then((cachedResponse) => {
             if (!cachedResponse) {
-              this.cachedUrls.delete(cacheKey)
+              this.cachedRequests.delete(cacheKey)
               return Promise.resolve(null);
             }         
             const cachedTime = cachedResponse.headers.get('X-Bazaarvoice-Cached-Time');
@@ -218,7 +256,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
             const cacheAge = (currentTimestamp - cachedTime) / 1000;
             if (cacheAge >= ttl) {
               cache.delete(key);
-              this.cachedUrls.delete(key);
+              this.cachedRequests.delete(key);
             }
           });
         });
@@ -266,7 +304,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
               cacheEntries.forEach(entry => {
                 if (currentSize > this.cacheLimit) {
                   cache.delete(entry.key);
-                  this.cachedUrls.delete(entry.key);
+                  this.cachedRequests.delete(entry.key);
                   currentSize -= entry.size;
                 }
               });

--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -22,25 +22,31 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
    * @returns {boolean} - Returns true if the request is found in the cachedRequests set, otherwise false.
    */
   function isRequestInSet (cachedRequests, cacheKey) {
-    // Convert the Set to an array and check if any request matches
-    return [...cachedRequests].some((cachedRequest) => {
-      // Compare URLs
-      if (cachedRequest.url !== cacheKey.url) {
-        return false;
-      }
-  
-      // Compare headers
-      const cachedHeaders = [...cachedRequest.headers.entries()];
-      const keyHeaders = [...cacheKey.headers.entries()];
-  
-      if (cachedHeaders.length !== keyHeaders.length) {
-        return false; // Different number of headers
-      }
-  
-      return cachedHeaders.every(([key, value]) => {
-        return cacheKey.headers.get(key) === value;
+    try {
+      // Convert the Set to an array and check if any request matches
+      return [...cachedRequests].some((cachedRequest) => {
+        // Compare URLs
+        if (cachedRequest.url !== cacheKey.url) {
+          return false;
+        }
+    
+        // Compare headers
+        const cachedHeaders = [...cachedRequest.headers.entries()];
+        const keyHeaders = [...cacheKey.headers.entries()];
+    
+        if (cachedHeaders.length !== keyHeaders.length) {
+          return false; // Different number of headers
+        }
+    
+        return cachedHeaders.every(([key, value]) => {
+          return cacheKey.headers.get(key) === value;
+        });
       });
-    });
+    } 
+    catch (error) {
+      console.warn('Error checking in if request is in cache: ', error);
+      return false;
+    }
   }
   
 
@@ -116,7 +122,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
     // Check for error in response obj
     errJson.json().then(json => {
       if (typeof this.shouldCache === 'function') {
-        canBeCached = this.shouldCache(json.response ? json.response : json);
+        canBeCached = this.shouldCache(json);
       }
     }).then(() => {
       if (canBeCached) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {

--- a/test/unit/bvFetch/index.spec.js
+++ b/test/unit/bvFetch/index.spec.js
@@ -39,7 +39,7 @@ describe('BvFetch', function () {
   it('should generate correct cache key', function () {
     const url = 'https://jsonplaceholder.typicode.com/todos';
     const options = {};
-    const expectedKey = 'https://jsonplaceholder.typicode.com/todos';
+    const expectedKey = new Request(url, options)
     const generatedKey = bvFetchInstance.generateCacheKey(url, options);
     expect(generatedKey).to.equal(expectedKey);
   });
@@ -74,7 +74,7 @@ describe('BvFetch', function () {
     });
   
     // Simulate that the response is cached
-    bvFetchInstance.cachedUrls.add(cacheKey);
+    bvFetchInstance.cachedRequests.add(cacheKey);
     
     // Call the function under test
     bvFetchInstance.bvFetchFunc(url, options)

--- a/test/unit/bvFetch/index.spec.js
+++ b/test/unit/bvFetch/index.spec.js
@@ -38,16 +38,27 @@ describe('BvFetch', function () {
   
   it('should generate correct cache key', function () {
     const url = 'https://jsonplaceholder.typicode.com/todos';
-    const options = {};
+    const options = {
+      method: 'GET',
+      headers: {
+        'X-Header-1': 'Value 1',
+      }
+    };
     const expectedKey = new Request(url, options)
     const generatedKey = bvFetchInstance.generateCacheKey(url, options);
-    expect(generatedKey).to.equal(expectedKey);
+    expect(generatedKey.url).to.equal(expectedKey.url);
+    expect(generatedKey.headers).to.deep.equal(expectedKey.headers);
   });
 
   
   it('should fetch from cache when the response is cached', function (done) {
     const url = 'https://jsonplaceholder.typicode.com/todos';
-    const options = {};
+    const options = {
+      method: 'GET',
+      headers: {
+        'X-Header-1': 'Value 1',
+      }
+    };
   
     // Mocking cache response
     const mockResponse = new Response('Mock Data', {
@@ -64,7 +75,8 @@ describe('BvFetch', function () {
     // Overriding the stub for this specific test case
     caches.open.resolves({
       match: (key) => {
-        expect(key).to.equal(cacheKey); 
+        expect(key.url).to.equal(cacheKey.url); 
+        expect(key.headers).to.deep.equal(cacheKey.headers);
         return Promise.resolve(mockResponse)
       },
       put: (key, response) => {


### PR DESCRIPTION
# PR description

<!--Mention the JIRA ticket numbers below-->

## JIRA tickets

[PD-260762](https://bazaarvoice.atlassian.net/browse/PD-260762)

<!--Please mention if the PR is for a feature or bug. Select both if it contains both-->

## This PR is for

- Bug

<!--Mention the requirements / issues in points-->

## Requirements / issues

- The bvFetch module does not honor the change in headers while retrieving the cached response

<!--Mention the steps taken to solve each of the above points-->

## Solutions

- When storing the response in cache the request headers are not a part of the cache key. Making changes so that the cache key is a request so that when retrieving the cache from the cache storage the request headers are available.
- For BFD the response obj in the api response should be passed to the error handling function



[PD-260762]: https://bazaarvoice.atlassian.net/browse/PD-260762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ