### PR TITLE
adding the exclude Headers functionality to exclude certain headers from the cacheKey

### DIFF
--- a/lib/bvFetch/README.md
+++ b/lib/bvFetch/README.md
@@ -9,6 +9,8 @@ The BvFetch module provides methods to cache duplicate API calls and interact wi
 `shouldCache (Function):` A function that takes the API response JSON as input and returns a boolean indicating whether to cache the response or not. This allows you to implement custom logic based on the response content. If caching is desired, the function should return true; otherwise, false.
 `cacheName (String):` Optional. Specifies the name of the cache to be used. If not provided, the default cache name 'bvCache' will be used.
 `cacheLimit (Integer)`: Optional. Specifies the cache size limit for the cache storage. Its value should be in MB. Default value is 10 MB.
+`excludeHeaders (Array[String])`: Includes the list of headers that are excluded from the cacheKey
+
 
 ## bvFetchFunc Method Parameters
 `url (String):` The URL of the API endpoint to fetch data from.
@@ -17,11 +19,16 @@ The BvFetch module provides methods to cache duplicate API calls and interact wi
 ## bvFetchFunc Return Value
 `Promise<Response>:` A promise that resolves to the API response. If the response is cached, it returns the cached response. Otherwise, it fetches data from the API endpoint, caches the response according to the caching logic, and returns the fetched response.
 
-## generateCacheKey Method Parameters:
-`url (String):` The URL of the API endpoint.
-`options (Object):` Optional request options.
-## generateCacheKey Return Value:
-`Request:` The generated cache key.
+## generateCacheKey Method
+
+Generates a cache key as a Request object for a given URL and options, filtering out any headers specified in `excludeHeaders`.
+
+**Parameters:**
+- `url (String)`: The URL of the API endpoint.
+- `options (Object)`: *(Optional)* Request options (e.g., headers, method, etc.).
+
+**Returns:**  
+`Request`: The generated Request object to be used as a cache key.
 
 ## retrievecachedRequests Method
 Retrieves cached Requests from the cache storage associated with the provided cache name.

--- a/lib/bvFetch/README.md
+++ b/lib/bvFetch/README.md
@@ -84,8 +84,10 @@ var BvFetch = require('bv-ui-core/lib/bvFetch')
 
 // Initialize BV Fetch instance
 const bvFetch = new BVFetch({
-  canBeCached: canBeCached, // optional
-  cacheName: "bvCache" // optional, default is "bvCache"
+   shouldCache: function(responseJson) => { /* return true or false */ }, // optional, callback function to check if the response is cachable
+   cacheName: "bvCache" // optional, default is "bvCache"
+   cacheLimit: 10, // optional but default is 10
+   excludeHeaders: [], // optional, list of headers to be excluded from cache
 });
 
 // Make API calls using bvFetchFunc method

--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -90,7 +90,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit, exclude
     const method = request.method || 'GET';
     // Convert headers to a sorted array of [key, value] pairs for consistency
     const headersArr = Array.from(request.headers.entries()).sort(([a], [b]) => a.localeCompare(b));
-    return JSON.stringify({ url, method, headers: headersArr });
+    return JSON.stringify([url, method, { headers: headersArr }]);
   }
 
   /**

--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -5,12 +5,13 @@
 
 const { fetch } = require('../polyfills/fetch')
 
-module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
+module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit, excludeHeaders = [] }) {
   this.shouldCache = shouldCache;
   this.cacheName = cacheName || 'bvCache';
   this.cacheLimit = cacheLimit * 1024 * 1024 || 10 * 1024 * 1024;
   this.fetchPromises = new Map();
   this.cachedRequests = new Set();
+  this.excludeHeaders = excludeHeaders;
 
   /**
    * Checks if a request is present in a set of cached URLs.
@@ -37,7 +38,7 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
         if (cachedHeaders.length !== keyHeaders.length) {
           return false; // Different number of headers
         }
-    
+        // Check if all headers match
         return cachedHeaders.every(([key, value]) => {
           return cacheKey.headers.get(key) === value;
         });
@@ -58,10 +59,42 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
      * @returns {Request} The created Request object.
      */
 
+  /**
+   * Generates a cache key as a Request object for the given URL and options.
+   * Filters out headers specified in `excludeHeaders` from the options before creating the Request.
+   *
+   * @param {string} url - The URL of the API endpoint.
+   * @param {Object} options - Optional request options (e.g., headers, method, etc.).
+   * @returns {Request} The generated Request object to be used as a cache key.
+   */
   this.generateCacheKey =  (url, options) => {
-    const key = new Request(url, options);
+    const filteredOptions = Object.assign({}, options);
+    if (filteredOptions.headers) {
+      const newHeaders = new Headers();
+      for (const [key, value] of Object.entries(filteredOptions.headers)) {
+        if (!this.excludeHeaders.includes(key)) {
+          newHeaders.set(key, value);
+        }
+      }
+      filteredOptions.headers = newHeaders;
+    }
+    const key = new Request(url, filteredOptions);
     return key;
   };
+
+   /**
+   * Serializes a request object into a JSON string for use as a cache key.
+   * The serialization includes the URL, method, and sorted headers of the request.
+   * @param {Request} request - The request object to serialize.
+   * @returns {string} A JSON string representing the serialized request.
+   */
+  this.serializeRequestKey = (request) => {
+    const url = request.url;
+    const method = request.method || 'GET';
+    // Convert headers to a sorted array of [key, value] pairs for consistency
+    const headersArr = Array.from(request.headers.entries()).sort(([a], [b]) => a.localeCompare(b));
+    return JSON.stringify({ url, method, headers: headersArr });
+  }
 
   /**
   * Retrieves cached Requests from the cache storage associated with the provided cache name.
@@ -76,7 +109,9 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
         keys.forEach(request => {
           const headers = {};
           request.headers.forEach((value, key) => {
-            headers[key] = value;
+            if (!this.excludeHeaders.includes(key)) {
+              headers[key] = value;
+            }
           });
 
           // Generate the cache key with headers and URL
@@ -119,6 +154,11 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
   this.cacheData = (response, cacheKey) => {
     const errJson = response.clone();
     let canBeCached = true;
+    if (!response.ok) {
+      // If the response is not ok, we don't cache it
+      canBeCached = false;
+      return;
+    }
     // Check for error in response obj
     errJson.json().then(json => {
       if (typeof this.shouldCache === 'function') {
@@ -206,11 +246,11 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
 
     const cacheKey = this.generateCacheKey(url, options);
   // If an ongoing fetch promise exists for the URL, return it
-    if (this.fetchPromises.has(cacheKey)) {
-      return this.fetchPromises.get(cacheKey).then(res => res.clone());
+    if (this.fetchPromises.has(this.serializeRequestKey(cacheKey))) {
+      return this.fetchPromises.get(this.serializeRequestKey(cacheKey)).then(res => res.clone());
     }
 
-  // Check if response is available in cache
+    // Check if response is available in cache
     const newPromise = this.fetchFromCache(cacheKey)
       .then((cachedResponse) => {
           // If response found in cache, return it
@@ -222,14 +262,14 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit }) {
       });
 
     // Store the ongoing fetch promise
-    this.fetchPromises.set(cacheKey, newPromise);
+    this.fetchPromises.set(this.serializeRequestKey(cacheKey), newPromise);
 
     //initiate cache cleanUp
     this.debounceCleanupExpiredCache();
 
     // When fetch completes or fails, remove the promise from the store
     newPromise.finally(() => {
-      this.fetchPromises.delete(cacheKey);
+      this.fetchPromises.delete(this.serializeRequestKey(cacheKey));
     });
 
     return newPromise.then(res => res.clone());

--- a/lib/bvFetch/index.js
+++ b/lib/bvFetch/index.js
@@ -69,15 +69,12 @@ module.exports = function BvFetch ({ shouldCache, cacheName, cacheLimit, exclude
    */
   this.generateCacheKey =  (url, options) => {
     const filteredOptions = Object.assign({}, options);
-    if (filteredOptions.headers) {
-      const newHeaders = new Headers();
-      for (const [key, value] of Object.entries(filteredOptions.headers)) {
-        if (!this.excludeHeaders.includes(key)) {
-          newHeaders.set(key, value);
-        }
+    this.excludeHeaders.forEach(header => {
+      if (filteredOptions.headers && filteredOptions.headers[header]) {
+        delete filteredOptions.headers[header];
       }
-      filteredOptions.headers = newHeaders;
     }
+    );
     const key = new Request(url, filteredOptions);
     return key;
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {


### PR DESCRIPTION
# PR description

<!--Mention the JIRA ticket numbers below-->

## JIRA tickets

[PD-286544](https://bazaarvoice.atlassian.net/browse/PD-286544)

<!--Please mention if the PR is for a feature or bug. Select both if it contains both-->

## This PR is for

- Bug

<!--Mention the requirements / issues in points-->

## Requirements / issues

- When traceId is added to the BFD api calls the caching mechanism breaks
- When duplicate api calls happens on the PDP in one load the api calls are repeated.

<!--Mention the steps taken to solve each of the above points-->

## Solutions
- Adding functionality to exclude certain headers from the cacheKey
- The ongoing promise is not returned when the duplicate api call happens on the page. Since the cacheKey is a request the key check is failing. Fixed this issue by stringyfing the request content.




[PD-286544]: https://bazaarvoice.atlassian.net/browse/PD-286544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ