### PR TITLE
Pd 310944

### DIFF
--- a/lib/global/index.js
+++ b/lib/global/index.js
@@ -18,7 +18,7 @@ var getGlobal = function () {
     windows object during transpilation with __esModule being set. Below code would support
     global import in all bundle use cases
   */
-  if (globalObj && globalObj.__esModule) {
+  if (globalObj && globalObj.__esModule && typeof window !== 'undefined' && globalObj !== window) {
     const proxyGlobal = new Proxy(globalObj, {
       get: function (target, prop) {
         if (prop === 'default') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.10",
+  "version": "2.9.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.11",
+  "version": "2.9.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.10",
+  "version": "2.9.11",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bv-ui-core",
-  "version": "2.9.11",
+  "version": "2.9.12",
   "license": "Apache 2.0",
   "description": "Bazaarvoice UI-related JavaScript",
   "repository": {

--- a/test/unit/global/index.spec.js
+++ b/test/unit/global/index.spec.js
@@ -24,4 +24,23 @@ describe('lib/global', function () {
     }
   });
 
+  it('should not wrap window in a Proxy when globalObj is window even if __esModule is set', function () {
+    if (typeof window !== 'undefined') {
+      window.__esModule = true;
+      var result = require('../../../lib/global');
+      // When globalObj === window, the proxy branch should be skipped,
+      // so the result should be strictly equal to window.
+      expect(result).to.equal(window);
+      delete window.__esModule;
+    }
+  });
+
+  it('should return the global object directly when __esModule is not set', function () {
+    if (typeof window !== 'undefined') {
+      delete window.__esModule;
+      var result = require('../../../lib/global');
+      expect(result).to.equal(window);
+    }
+  });
+
 });


### PR DESCRIPTION
## JIRA
[PD-310944](https://bazaarvoice.atlassian.net/browse/PD-310944)

## Problem
The global module wraps the global object in a `Proxy` when `__esModule` is set on it. In browser environments, `globalObj` resolves to `window` via `globalThis`. If `window.__esModule` gets set (e.g., due to namespace pollution from bundler transpilation), the Proxy wraps `window` itself. This causes **"Illegal invocation"** errors when native browser APIs (like `setTimeout`, `fetch`, `requestAnimationFrame`) are called through the Proxy, because they expect `this` to be the real `window` object, not a Proxy.

## Solution
Added two additional guards to the `__esModule` Proxy condition:

```js
if (globalObj && globalObj.__esModule && typeof window !== 'undefined' && globalObj !== window)
```

- `typeof window !== 'undefined'` — ensures we're in a browser context before comparing.
- `globalObj !== window` — skips Proxy wrapping when `globalObj` is already `window`, since `window` doesn't need bridging. The Proxy is now only applied when `globalObj` is a bundler-generated module namespace object that is distinct from `window`.

## Test Cases Added
1. **"should not wrap window in a Proxy when globalObj is window even if __esModule is set"** — Verifies that when `window.__esModule` is `true`, the module still returns `window` directly (not a Proxy), confirming the `globalObj !== window` guard works.
2. **"should return the global object directly when __esModule is not set"** — Verifies the baseline behavior: when `__esModule` is absent, the module returns `window` as-is.

[PD-310944]: https://bazaarvoice.atlassian.net/browse/PD-310944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ